### PR TITLE
Enable `AnimationGraphPlayer` to pass parameters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
 
   # Run cargo publish pipeline as a dry run
   dry_run:
-    name: Test Suite
+    name: Dry Run Publish
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Run cargo test
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Run cargo test
+        run: cargo test
+
+  # Run cargo clippy -- -D warnings
+  clippy_check:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  # Run cargo publish pipeline as a dry run
+  dry_run:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Run cargo test
+        run: cargo publish --dry-run
+
+  # Run cargo fmt --all -- --check
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - name: Run cargo test
+      - name: Run cargo publish dry run
         run: cargo publish --dry-run
 
   # Run cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,11 +245,11 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 3.1.2",
+ "async-lock 3.2.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "slab",
 ]
 
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea8b3453dd7cc96711834b75400d671b73e3656975fa68d9f277163b7f7e316"
+checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
 dependencies = [
  "event-listener 4.0.0",
  "event-listener-strategy",
@@ -437,7 +437,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -503,7 +503,7 @@ checksum = "f484318350462c58ba3942a45a656c1fd6b6e484a6b6b7abc3a787ad1a51e500"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -551,7 +551,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc-hash",
- "syn 2.0.39",
+ "syn 2.0.41",
  "toml_edit 0.20.7",
 ]
 
@@ -806,7 +806,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "uuid",
 ]
 
@@ -865,7 +865,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1035,7 +1035,7 @@ checksum = "7aafecc952b6b8eb1a93c12590bd867d25df2f4ae1033a01dfdfc3c35ebccfff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1096,7 +1096,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1174,11 +1174,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
  "async-channel 2.1.1",
- "async-lock 3.1.2",
+ "async-lock 3.2.0",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.0.1",
+ "futures-lite 2.1.0",
  "piper",
  "tracing",
 ]
@@ -1206,7 +1206,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1378,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -1524,7 +1524,7 @@ checksum = "3fe2568f851fd6144a45fa91cfed8fe5ca8fc0b56ba6797bfc1ed2771b90e37c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1651,7 +1651,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1695,14 +1695,13 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+checksum = "aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
  "futures-io",
- "memchr",
  "parking",
  "pin-project-lite",
 ]
@@ -1722,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9eec02069fcbd7abe00a28adf216547774889129a777cb5e53fdfb75d59f09"
+checksum = "d8b2e57a9cb946b5d04ae8638c5f554abb5a9f82c4c950fd5b1fee6d119592fb"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -1808,7 +1807,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2034,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jni"
@@ -2135,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
@@ -2262,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
@@ -2479,7 +2478,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2570,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "orbclient"
@@ -2721,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89dff0959d98c9758c88826cc002e2c3d0b9dfac4139711d1f30de442f1139b"
+checksum = "1de09527cd2ea2c2d59fb6c2f8c1ab8c71709ed9d1b6d60b0e1c9fbb6fdcb33c"
 
 [[package]]
 name = "quote"
@@ -2879,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -2915,7 +2914,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2961,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "slotmap"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
  "version_check",
 ]
@@ -3021,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3091,7 +3090,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -3102,7 +3101,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -3177,7 +3176,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -3346,7 +3345,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -3380,7 +3379,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3782,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.19"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
 dependencies = [
  "memchr",
 ]
@@ -3814,20 +3813,20 @@ checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.27"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43de342578a3a14a9314a2dab1942cbfcbe5686e1f91acdc513058063eafe18"
+checksum = "306dca4455518f1f31635ec308b6b3e4eb1b11758cefafc782827d0aa7acb5c7"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.27"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1012d89e3acb79fad7a799ce96866cfb8098b74638465ea1b1533d35900ca90"
+checksum = "be912bf68235a88fbefd1b73415cb218405958d1655b2ece9035a19920bdf6ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]

--- a/examples/human.rs
+++ b/examples/human.rs
@@ -65,13 +65,17 @@ fn setup(
         },
         Human,
     ));
+
+    println!("Controls:");
+    println!("\tSPACE: Play/Pause animation");
+    println!("\tR: Reset animation");
+    println!("\tUp/Down: Increase/decrease movement speed");
 }
 
 fn keyboard_animation_control(
     keyboard_input: Res<Input<KeyCode>>,
     human_character: Query<&AnimatedSceneInstance, With<Human>>,
     mut animation_players: Query<&mut AnimationGraphPlayer>,
-    mut animation_graphs: ResMut<Assets<AnimationGraph>>,
     mut velocity: Local<f32>,
     time: Res<Time>,
 ) {
@@ -94,29 +98,14 @@ fn keyboard_animation_control(
         player.reset();
     }
 
-    let Some(graph_handle) = player.get_animation_graph() else {
-        return;
-    };
-
-    let Some(graph) = animation_graphs.get_mut(graph_handle) else {
-        return;
-    };
-
-    let mut velocity_changed = false;
     if keyboard_input.pressed(KeyCode::Up) {
         *velocity += 0.5 * time.delta_seconds();
-        velocity_changed = true;
     }
     if keyboard_input.pressed(KeyCode::Down) {
         *velocity -= 0.5 * time.delta_seconds();
-        velocity_changed = true;
     }
 
     *velocity = velocity.max(0.);
 
-    if velocity_changed {
-        println!("velocity: {}", *velocity);
-    }
-
-    graph.set_input_parameter("Target Speed", (*velocity).into());
+    player.set_input_parameter("Target Speed", (*velocity).into());
 }

--- a/src/chaining/mod.rs
+++ b/src/chaining/mod.rs
@@ -19,16 +19,14 @@ impl<T: TypePath + FromReflect + Clone> Chainable for ValueFrame<T> {
             out_pose
         } else if self.next_is_wrapped {
             // First pose is active, but next pose wraps around
-            let out_pose = Self {
+            Self {
                 timestamp: self.timestamp,
                 prev: self.prev.clone(),
                 prev_timestamp: self.prev_timestamp,
                 next: other.prev.clone(),
                 next_timestamp: other.prev_timestamp + duration_first,
                 next_is_wrapped: false,
-            };
-
-            out_pose
+            }
         } else {
             self.clone()
         }
@@ -51,7 +49,7 @@ impl<T: TypePath + FromReflect + Clone> Chainable for Option<ValueFrame<T>> {
                 let mut out = frame_1.clone();
 
                 if out.next_is_wrapped {
-                    out.next_timestamp = out.next_timestamp + duration_second;
+                    out.next_timestamp += duration_second;
                 }
 
                 Some(out)

--- a/src/core/animated_scene.rs
+++ b/src/core/animated_scene.rs
@@ -184,10 +184,7 @@ pub(crate) fn process_animated_scenes(
         commands
             .entity(next_entity)
             .remove::<AnimationPlayer>()
-            .insert(AnimationGraphPlayer {
-                animation: Some(animscn.animation_graph.clone()),
-                ..Default::default()
-            });
+            .insert(AnimationGraphPlayer::new().with_graph(animscn.animation_graph.clone()));
         commands
             .entity(animscn_entity)
             .insert(AnimatedSceneInstance {

--- a/src/core/animated_scene.rs
+++ b/src/core/animated_scene.rs
@@ -102,6 +102,7 @@ pub(crate) fn spawn_animated_scenes(
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub(crate) fn process_animated_scenes(
     mut commands: Commands,
     unloaded_scenes: Query<

--- a/src/core/animation_graph/core.rs
+++ b/src/core/animation_graph/core.rs
@@ -728,17 +728,17 @@ impl AnimationGraph {
         overlay: &HashMap<String, AnimationNode>,
     ) -> Pose {
         context.push_caches();
-        self.parameter_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, &overlay);
-        self.duration_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, &overlay);
+        self.parameter_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, overlay);
+        self.duration_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, overlay);
         self.time_pass(
             Self::OUTPUT_NODE,
             vec![],
             time_update,
             context,
             context_tmp,
-            &overlay,
+            overlay,
         );
-        self.time_dependent_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, &overlay);
+        self.time_dependent_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, overlay);
 
         let output = context
             .get_time_dependent(Self::OUTPUT_NODE, &vec![])

--- a/src/core/animation_graph/core.rs
+++ b/src/core/animation_graph/core.rs
@@ -740,10 +740,18 @@ impl AnimationGraph {
         context: &mut GraphContext,
         context_tmp: &mut GraphContextTmp,
     ) -> Pose {
+        self.query_with_overlay(time_update, context, context_tmp, &HashMap::new())
+    }
+
+    pub fn query_with_overlay(
+        &self,
+        time_update: TimeUpdate,
+        context: &mut GraphContext,
+        context_tmp: &mut GraphContextTmp,
+        overlay: &HashMap<String, AnimationNode>,
+    ) -> Pose {
         context.push_caches();
-        let overlay = HashMap::new();
         self.parameter_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, &overlay);
-        // self.dot_to_tmp_file(Some(context)).unwrap();
         self.duration_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, &overlay);
         self.time_pass(
             Self::OUTPUT_NODE,
@@ -754,7 +762,6 @@ impl AnimationGraph {
             &overlay,
         );
         self.time_dependent_pass(Self::OUTPUT_NODE, vec![], context, context_tmp, &overlay);
-        // self.dot_to_tmp_file(Some(context)).unwrap();
 
         let output = context
             .get_time_dependent(Self::OUTPUT_NODE, &vec![])

--- a/src/core/animation_graph/dot_output.rs
+++ b/src/core/animation_graph/dot_output.rs
@@ -76,13 +76,13 @@ pub trait ToDot {
         let pdf_path_alt = "/tmp/bevy_animation_graph_dot.dot.pdf_alt";
 
         {
-            let file = File::create(&path)?;
+            let file = File::create(path)?;
             let mut writer = BufWriter::new(file);
             self.to_dot(&mut writer, context, context_tmp)?;
         }
 
         {
-            let pdf_file_alt = File::create(&pdf_path_alt)?;
+            let pdf_file_alt = File::create(pdf_path_alt)?;
             Command::new("dot")
                 .args([path, "-Tpdf"])
                 .stdout(pdf_file_alt)
@@ -225,7 +225,7 @@ fn write_debugdump(
     write!(f, "<TR><TD COLSPAN=\"2\"><i>DebugDump</i></TD></TR>")?;
     if let Some(param_cache) = context
         .get_node_cache(&node.name)
-        .map_or(None, |nc| nc.parameter_cache.as_ref())
+        .and_then(|nc| nc.parameter_cache.as_ref())
     {
         write!(f, "<TR><TD COLSPAN=\"2\">Parameters</TD></TR>")?;
         write!(f, "<TR>")?;
@@ -239,7 +239,7 @@ fn write_debugdump(
     }
     if let Some(duration_cache) = context
         .get_node_cache(&node.name)
-        .map_or(None, |nc| nc.duration_cache.as_ref())
+        .and_then(|nc| nc.duration_cache.as_ref())
     {
         write!(f, "<TR><TD COLSPAN=\"2\">Durations</TD></TR>")?;
         write!(f, "<TR>")?;
@@ -372,9 +372,7 @@ impl ToDot for AnimationGraph {
         for ((end_node, end_edge), (start_node, start_edge)) in self.node_edges.iter() {
             let node = self.nodes.get(start_node).unwrap();
             let mut spec = node.parameter_output_spec(ctx, context_tmp);
-            spec.fill_up(&node.time_dependent_output_spec(ctx, context_tmp), &|v| {
-                v.clone()
-            });
+            spec.fill_up(&node.time_dependent_output_spec(ctx, context_tmp), &|v| *v);
             let tp = spec.get(start_edge).unwrap();
             let color = match tp {
                 EdgeSpec::PoseFrame => "chartreuse4",

--- a/src/core/animation_graph/loader.rs
+++ b/src/core/animation_graph/loader.rs
@@ -56,11 +56,11 @@ impl AssetLoader for GraphClipLoader {
                     let gltf: &Gltf = gltf_loaded_asset.get().unwrap();
 
                     let Some(clip_handle) = gltf.named_animations.get(&animation_name) else {
-                        return Err(AssetLoaderError::GltfMissingLabel(animation_name.into()));
+                        return Err(AssetLoaderError::GltfMissingLabel(animation_name));
                     };
 
                     let Some(clip_path) = clip_handle.path() else {
-                        return Err(AssetLoaderError::GltfMissingLabel(animation_name.into()));
+                        return Err(AssetLoaderError::GltfMissingLabel(animation_name));
                     };
 
                     let clip_bevy: bevy::animation::AnimationClip = gltf_loaded_asset
@@ -183,15 +183,15 @@ impl AssetLoader for AnimationGraphLoader {
             }
 
             for (td_name, td_spec) in &serial.input_time_dependent_spec {
-                graph.register_input_td(td_name, td_spec.clone());
+                graph.register_input_td(td_name, *td_spec);
             }
 
             for (p_name, p_spec) in &serial.output_parameter_spec {
-                graph.register_output_parameter(p_name, p_spec.clone());
+                graph.register_output_parameter(p_name, *p_spec);
             }
 
             for (td_name, td_spec) in &serial.output_time_dependent_spec {
-                graph.register_output_td(td_name, td_spec.clone());
+                graph.register_output_td(td_name, *td_spec);
             }
 
             for (parameter_name, (target_node, target_edge)) in &serial.input_edges {

--- a/src/core/animation_graph_player.rs
+++ b/src/core/animation_graph_player.rs
@@ -1,8 +1,11 @@
+use crate::{prelude::GraphContextTmp, utils::hash_map_join::HashMapOpsExt};
+
 use super::{
-    animation_graph::{AnimationGraph, TimeState, TimeUpdate},
+    animation_graph::{AnimationGraph, EdgeValue, TimeState, TimeUpdate},
     graph_context::GraphContext,
+    pose::Pose,
 };
-use bevy::{asset::prelude::*, ecs::prelude::*, reflect::prelude::*};
+use bevy::{asset::prelude::*, ecs::prelude::*, reflect::prelude::*, utils::HashMap};
 
 /// Animation controls
 #[derive(Component, Default, Reflect)]
@@ -13,9 +16,45 @@ pub struct AnimationGraphPlayer {
     pub(crate) elapsed: TimeState,
     pub(crate) pending_update: Option<TimeUpdate>,
     pub(crate) context: GraphContext,
+
+    input_parameters: HashMap<String, EdgeValue>,
 }
 
 impl AnimationGraphPlayer {
+    /// Create a new animation graph player, with no graph playing
+    pub fn new() -> Self {
+        Self {
+            paused: false,
+            animation: None,
+            elapsed: TimeState::default(),
+            pending_update: None,
+            context: GraphContext::default(),
+
+            input_parameters: HashMap::new(),
+        }
+    }
+
+    /// Set the animation graph to play
+    pub fn with_graph(mut self, animation: Handle<AnimationGraph>) -> Self {
+        self.animation = Some(animation);
+        self
+    }
+
+    /// Clear all input parameters for the animation graph
+    pub fn clear_input_parameter(&mut self) {
+        self.input_parameters.clear();
+    }
+
+    /// Configure an input parameter for the animation graph
+    pub fn set_input_parameter(&mut self, parameter_name: impl Into<String>, value: EdgeValue) {
+        self.input_parameters.insert(parameter_name.into(), value);
+    }
+
+    /// Return an input parameter for the animation graph
+    pub fn get_input_parameter(&self, parameter_name: &str) -> Option<EdgeValue> {
+        self.input_parameters.get(parameter_name).cloned()
+    }
+
     /// Start playing an animation, resetting state of the player.
     /// This will use a linear blending between the previous and the new animation to make a smooth transition.
     pub fn start(&mut self, handle: Handle<AnimationGraph>) -> &mut Self {
@@ -23,6 +62,31 @@ impl AnimationGraphPlayer {
         self.elapsed = TimeState::default();
         self.paused = false;
         self
+    }
+
+    /// Query the animation graph with the latest time update and inputs
+    pub(crate) fn query(&mut self, context_tmp: &mut GraphContextTmp) -> Option<Pose> {
+        let Some(graph_handle) = &self.animation else {
+            return None;
+        };
+
+        let Some(graph) = context_tmp.animation_graph_assets.get(graph_handle) else {
+            return None;
+        };
+
+        let mut overlay_input_node = graph.nodes.get(AnimationGraph::INPUT_NODE).unwrap().clone();
+        overlay_input_node
+            .node
+            .unwrap_input_mut()
+            .parameters
+            .extend_replacing_owned(self.input_parameters.clone());
+
+        Some(graph.query_with_overlay(
+            self.elapsed.update,
+            &mut self.context,
+            context_tmp,
+            &HashMap::from([(AnimationGraph::INPUT_NODE.into(), overlay_input_node)]),
+        ))
     }
 
     pub fn pause(&mut self) -> &mut Self {

--- a/src/core/frame.rs
+++ b/src/core/frame.rs
@@ -35,10 +35,18 @@ impl BoneFrame {
     where
         F: Fn(f32) -> f32,
     {
-        self.rotation.as_mut().map(|v| v.map_ts(&f));
-        self.translation.as_mut().map(|v| v.map_ts(&f));
-        self.scale.as_mut().map(|v| v.map_ts(&f));
-        self.weights.as_mut().map(|v| v.map_ts(&f));
+        if let Some(v) = self.rotation.as_mut() {
+            v.map_ts(&f)
+        };
+        if let Some(v) = self.translation.as_mut() {
+            v.map_ts(&f)
+        };
+        if let Some(v) = self.scale.as_mut() {
+            v.map_ts(&f)
+        };
+        if let Some(v) = self.weights.as_mut() {
+            v.map_ts(&f)
+        };
     }
 }
 

--- a/src/core/graph_context.rs
+++ b/src/core/graph_context.rs
@@ -5,23 +5,13 @@ use super::{
 };
 use bevy::{asset::Assets, reflect::prelude::*, utils::HashMap};
 
-#[derive(Reflect, Debug)]
+#[derive(Reflect, Debug, Default)]
 pub struct GraphContext {
     /// Caches are double buffered
     caches: [HashMap<String, AnimationCaches>; 2],
     current_cache: usize,
     #[reflect(ignore)]
     subgraph_contexts: HashMap<String, GraphContext>,
-}
-
-impl Default for GraphContext {
-    fn default() -> Self {
-        Self {
-            caches: [HashMap::default(), HashMap::default()],
-            current_cache: 0,
-            subgraph_contexts: HashMap::default(),
-        }
-    }
 }
 
 /// Contains temprary data such as references to assets, gizmos, etc.
@@ -90,12 +80,12 @@ impl GraphContext {
 
     pub fn get_other_parameters(&self, node: &str) -> Option<&ParameterCache> {
         self.get_node_other_cache(node)
-            .map_or(None, |c| c.parameter_cache.as_ref())
+            .and_then(|c| c.parameter_cache.as_ref())
     }
 
     pub fn get_other_durations(&self, node: &str) -> Option<&DurationCache> {
         self.get_node_other_cache(node)
-            .map_or(None, |c| c.duration_cache.as_ref())
+            .and_then(|c| c.duration_cache.as_ref())
     }
 
     pub fn get_other_times(&self, node: &str, path: &EdgePath) -> Option<&TimeCache> {

--- a/src/core/systems.rs
+++ b/src/core/systems.rs
@@ -140,13 +140,13 @@ pub fn run_animation_player(
         animation_graph_assets: &graphs,
     };
 
-    let Some(graph) = graphs.get(player.animation.as_ref().unwrap()) else {
+    let Some(out_pose) = player.query(&mut context_tmp) else {
         return;
     };
 
     // Apply the main animation
     apply_pose(
-        &graph.query(player.elapsed.update, &mut player.context, &mut context_tmp),
+        &out_pose,
         root,
         names,
         transforms,

--- a/src/core/systems.rs
+++ b/src/core/systems.rs
@@ -137,7 +137,7 @@ pub fn run_animation_player(
 
     let mut context_tmp = GraphContextTmp {
         graph_clip_assets: graph_clips,
-        animation_graph_assets: &graphs,
+        animation_graph_assets: graphs,
     };
 
     let Some(out_pose) = player.query(&mut context_tmp) else {
@@ -232,7 +232,7 @@ fn apply_pose(
         }
         if let Some(weights) = &pose.weights {
             if let Ok(morphs) = &mut morphs {
-                apply_morph_weights(morphs.weights_mut(), &weights);
+                apply_morph_weights(morphs.weights_mut(), weights);
             }
         }
     }

--- a/src/interpolation/linear.rs
+++ b/src/interpolation/linear.rs
@@ -69,7 +69,7 @@ impl<T: InterpolateLinear + FromReflect + TypePath + std::fmt::Debug + Clone> In
             );
         }
 
-        let out = Self {
+        Self {
             timestamp: self.timestamp,
             prev,
             prev_timestamp: self.prev_timestamp.max(other.prev_timestamp),
@@ -81,9 +81,7 @@ impl<T: InterpolateLinear + FromReflect + TypePath + std::fmt::Debug + Clone> In
             } else {
                 other.next_is_wrapped
             },
-        };
-
-        out
+        }
     }
 }
 
@@ -95,7 +93,7 @@ impl InterpolateLinear for BoneFrame {
 
         match (&self.rotation, &other.rotation) {
             (Some(a), Some(b)) => {
-                result.rotation = Some(a.interpolate_linear(&b, f));
+                result.rotation = Some(a.interpolate_linear(b, f));
             }
             (None, None) => {}
             (None, Some(b)) => result.rotation = Some(b.clone()),
@@ -104,7 +102,7 @@ impl InterpolateLinear for BoneFrame {
 
         match (&self.translation, &other.translation) {
             (Some(a), Some(b)) => {
-                result.translation = Some(a.interpolate_linear(&b, f));
+                result.translation = Some(a.interpolate_linear(b, f));
             }
             (None, None) => {}
             (None, Some(b)) => result.translation = Some(b.clone()),
@@ -113,7 +111,7 @@ impl InterpolateLinear for BoneFrame {
 
         match (&self.scale, &other.scale) {
             (Some(a), Some(b)) => {
-                result.scale = Some(a.interpolate_linear(&b, f));
+                result.scale = Some(a.interpolate_linear(b, f));
             }
             (None, None) => {}
             (None, Some(b)) => result.scale = Some(b.clone()),
@@ -122,7 +120,7 @@ impl InterpolateLinear for BoneFrame {
 
         match (&self.weights, &other.weights) {
             (Some(a), Some(b)) => {
-                result.weights = Some(a.interpolate_linear(&b, f));
+                result.weights = Some(a.interpolate_linear(b, f));
             }
             (None, None) => {}
             (None, Some(b)) => result.weights = Some(b.clone()),

--- a/src/nodes/blend_node.rs
+++ b/src/nodes/blend_node.rs
@@ -7,7 +7,7 @@ use crate::interpolation::linear::InterpolateLinear;
 use bevy::prelude::*;
 use bevy::utils::HashMap;
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(Reflect, Clone, Debug, Default)]
 pub struct BlendNode;
 
 impl BlendNode {
@@ -45,8 +45,8 @@ impl NodeLike for BlendNode {
         _context: &mut GraphContext,
         _context_tmp: &mut GraphContextTmp,
     ) -> HashMap<NodeOutput, Option<f32>> {
-        let duration_1 = *inputs.get(Self::INPUT_1.into()).unwrap();
-        let duration_2 = *inputs.get(Self::INPUT_2.into()).unwrap();
+        let duration_1 = *inputs.get(Self::INPUT_1).unwrap();
+        let duration_2 = *inputs.get(Self::INPUT_2).unwrap();
 
         let out_duration = match (duration_1, duration_2) {
             (Some(duration_1), Some(duration_2)) => Some(duration_1.max(duration_2)),

--- a/src/nodes/chain_node.rs
+++ b/src/nodes/chain_node.rs
@@ -7,7 +7,7 @@ use crate::core::graph_context::{GraphContext, GraphContextTmp};
 use bevy::prelude::*;
 use bevy::utils::HashMap;
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(Reflect, Clone, Debug, Default)]
 pub struct ChainNode {}
 
 impl ChainNode {
@@ -44,8 +44,8 @@ impl NodeLike for ChainNode {
         _context: &mut GraphContext,
         _context_tmp: &mut GraphContextTmp,
     ) -> HashMap<NodeOutput, Option<f32>> {
-        let source_duration_1 = *inputs.get(Self::INPUT_1.into()).unwrap();
-        let source_duration_2 = *inputs.get(Self::INPUT_2.into()).unwrap();
+        let source_duration_1 = *inputs.get(Self::INPUT_1).unwrap();
+        let source_duration_2 = *inputs.get(Self::INPUT_2).unwrap();
 
         let out_duration = match (source_duration_1, source_duration_2) {
             (Some(duration_1), Some(duration_2)) => Some(duration_1 + duration_2),
@@ -115,12 +115,12 @@ impl NodeLike for ChainNode {
         _context_tmp: &mut GraphContextTmp,
     ) -> HashMap<NodeOutput, EdgeValue> {
         let in_pose_1 = inputs
-            .get(Self::INPUT_1.into())
+            .get(Self::INPUT_1)
             .unwrap()
             .clone()
             .unwrap_pose_frame();
         let in_pose_2 = inputs
-            .get(Self::INPUT_2.into())
+            .get(Self::INPUT_2)
             .unwrap()
             .clone()
             .unwrap_pose_frame();

--- a/src/nodes/clip_node.rs
+++ b/src/nodes/clip_node.rs
@@ -226,7 +226,7 @@ impl NodeLike for ClipNode {
         _context: &mut GraphContext,
         _context_tmp: &mut GraphContextTmp,
     ) -> HashMap<NodeOutput, EdgeSpec> {
-        return HashMap::from([(Self::OUTPUT.into(), EdgeSpec::PoseFrame)]);
+        HashMap::from([(Self::OUTPUT.into(), EdgeSpec::PoseFrame)])
     }
 
     fn display_name(&self) -> String {

--- a/src/nodes/flip_lr_node.rs
+++ b/src/nodes/flip_lr_node.rs
@@ -10,6 +10,12 @@ use bevy::utils::HashMap;
 #[derive(Reflect, Clone, Debug)]
 pub struct FlipLRNode {}
 
+impl Default for FlipLRNode {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FlipLRNode {
     pub const INPUT: &'static str = "Pose In";
     pub const OUTPUT: &'static str = "Pose Out";
@@ -43,10 +49,7 @@ impl NodeLike for FlipLRNode {
         _context: &mut GraphContext,
         _context_tmp: &mut GraphContextTmp,
     ) -> HashMap<NodeOutput, Option<f32>> {
-        HashMap::from([(
-            Self::OUTPUT.into(),
-            *inputs.get(Self::INPUT.into()).unwrap(),
-        )])
+        HashMap::from([(Self::OUTPUT.into(), *inputs.get(Self::INPUT).unwrap())])
     }
 
     fn time_pass(

--- a/src/nodes/graph_node.rs
+++ b/src/nodes/graph_node.rs
@@ -140,7 +140,6 @@ impl NodeLike for GraphNode {
             .get_times(AnimationGraph::INPUT_NODE, path)
             .unwrap()
             .downstream
-            .clone()
             .update;
 
         // TODO: Think whether we want nodes to receive separate time queries per time-dependent

--- a/src/nodes/speed_node.rs
+++ b/src/nodes/speed_node.rs
@@ -5,7 +5,7 @@ use crate::core::animation_node::{AnimationNode, AnimationNodeType, NodeLike};
 use crate::core::graph_context::{GraphContext, GraphContextTmp};
 use bevy::{reflect::Reflect, utils::HashMap};
 
-#[derive(Reflect, Clone, Debug)]
+#[derive(Reflect, Clone, Debug, Default)]
 pub struct SpeedNode;
 
 impl SpeedNode {
@@ -54,11 +54,7 @@ impl NodeLike for SpeedNode {
             None
         } else {
             let duration = inputs.get(Self::INPUT).unwrap();
-            if let Some(duration) = duration {
-                Some(duration / speed)
-            } else {
-                None
-            }
+            duration.as_ref().map(|duration| duration / speed)
         };
 
         HashMap::from([(Self::OUTPUT.into(), out_duration)])


### PR DESCRIPTION
## Objective

Currently the only way to set input parameters of a top-level graph (i.e. a graph assigned directly to an `AnimationGraphPlayer`) is to access the asset mutably and modify its parameter node. This would require cloning the asset every time we would like to have a new actor play the graph, which is inefficient. Ideally, we would set the parameters on `AnimationGraphPlayer` directly, and the player would then pass the parameters when querying the graph as a node overlay.

## Solution

Enable setting parameters in the `AnimationGraphPlayer`, similarly to how `GraphNode` does it.