### PR TITLE
fix: clip_node crashes if called before loading is finished

### DIFF
--- a/src/core/frame.rs
+++ b/src/core/frame.rs
@@ -367,7 +367,7 @@ impl std::fmt::Debug for InnerPoseFrame {
     }
 }
 
-#[derive(Clone, Reflect, Debug)]
+#[derive(Clone, Reflect, Debug, Default)]
 pub struct PoseFrame {
     pub data: PoseFrameData,
     pub timestamp: f32,

--- a/src/nodes/clip_node.rs
+++ b/src/nodes/clip_node.rs
@@ -50,7 +50,9 @@ impl NodeLike for ClipNode {
 
     fn pose_pass(&self, time_update: TimeUpdate, ctx: PassContext) -> Option<PoseFrame> {
         let clip_duration = self.clip_duration(&ctx);
-        let clip = ctx.resources.graph_clip_assets.get(&self.clip).unwrap();
+        let Some(clip) = ctx.resources.graph_clip_assets.get(&self.clip) else {
+            return Some(PoseFrame::default());
+        };
 
         let prev_time = ctx.prev_time_fwd();
         let time = time_update.apply(prev_time);


### PR DESCRIPTION
`ClipNode` crashes if the pose pass is called before the attached clip has finished loading. In this case we can just return a default (unmodified) pose.