### PR TITLE
Inverse kinematics for two-bone chains

### DIFF
--- a/assets/animation_graphs/human_ik.animgraph.ron
+++ b/assets/animation_graphs/human_ik.animgraph.ron
@@ -22,7 +22,7 @@
         "Target Direction": Vec3((1., 0., 0.)),
 
         "Target Path": EntityPath(["Main Controller", "Main Controller", "Hip", "Waist", "Chest", "Shoulder L", "Upper Arm L", "Lower Arm L", "Wrist L"]),
-        "Target Position": Vec3((0., 1., 0.)),
+        "Target Position": Vec3((1., 1., 0.)),
 
         // Constant 
         "Rotation Mask": BoneMask(

--- a/assets/animation_graphs/human_ik.animgraph.ron
+++ b/assets/animation_graphs/human_ik.animgraph.ron
@@ -14,10 +14,7 @@
         (name: "Make Rotation", node: RotationArc),
         (name: "Rotate", node: Rotation),
         (name: "Extend to skeleton", node: ExtendSkeleton),
-        (name: "ToCharacter", node: IntoCharacterSpace),
         (name: "DoIK", node: TwoBoneIK),
-        (name: "ToBone", node: IntoBoneSpace),
-
         (name: "Param graph", node: Graph("animation_graphs/velocity_to_params.animgraph.ron")),
     ],
     input_parameters: {
@@ -49,7 +46,7 @@
         ("Target Path", ("DoIK", "Target Path")),
         ("Target Position", ("DoIK", "Target Position")),
     ],
-    output_pose_edge: Some("ToBone"),
+    output_pose_edge: Some("DoIK"),
     parameter_edges: [
         (("Param graph", "blend_fac"),("Blend", "Factor")),
         (("Param graph", "speed_fac"),("Speed", "Speed")),
@@ -68,8 +65,6 @@
         ("Loop", ("Speed", "Pose In")),
         ("Speed", ("Rotate", "Pose In")),
         ("Rotate", ("Extend to skeleton", "Pose In")),
-        ("Extend to skeleton", ("ToCharacter", "Pose In")),
-        ("ToCharacter", ("DoIK", "Pose In")),
-        ("DoIK", ("ToBone", "Pose In"))
+        ("Extend to skeleton", ("DoIK", "Pose In")),
     ],
 )

--- a/assets/animation_graphs/human_ik.animgraph.ron
+++ b/assets/animation_graphs/human_ik.animgraph.ron
@@ -15,6 +15,7 @@
         (name: "Rotate", node: Rotation),
         (name: "Extend to skeleton", node: ExtendSkeleton),
         (name: "ToCharacter", node: IntoCharacterSpace),
+        (name: "DoIK", node: TwoBoneIK),
         (name: "ToBone", node: IntoBoneSpace),
 
         (name: "Param graph", node: Graph("animation_graphs/velocity_to_params.animgraph.ron")),
@@ -22,6 +23,9 @@
     input_parameters: {
         "Target Speed": F32(1.5),
         "Target Direction": Vec3((1., 0., 0.)),
+
+        "Target Path": EntityPath(["Main Controller", "Main Controller", "Hip", "Waist", "Chest", "Shoulder L", "Upper Arm L", "Lower Arm L", "Wrist L"]),
+        "Target Position": Vec3((0., 1., 0.)),
 
         // Constant 
         "Rotation Mask": BoneMask(
@@ -41,6 +45,9 @@
         ("Target Direction", ("Make Rotation", "Vec3 In 2")),
 
         ("Rotation Mask", ("Rotate", "Bone Mask")),
+
+        ("Target Path", ("DoIK", "Target Path")),
+        ("Target Position", ("DoIK", "Target Position")),
     ],
     output_pose_edge: Some("ToBone"),
     parameter_edges: [
@@ -62,6 +69,7 @@
         ("Speed", ("Rotate", "Pose In")),
         ("Rotate", ("Extend to skeleton", "Pose In")),
         ("Extend to skeleton", ("ToCharacter", "Pose In")),
-        ("ToCharacter", ("ToBone", "Pose In")),
+        ("ToCharacter", ("DoIK", "Pose In")),
+        ("DoIK", ("ToBone", "Pose In"))
     ],
 )

--- a/src/core/animation_clip.rs
+++ b/src/core/animation_clip.rs
@@ -52,6 +52,24 @@ impl EntityPath {
         new_path.parts.push(child.into());
         new_path
     }
+
+    pub fn parent(&self) -> Option<Self> {
+        let mut parent = self.clone();
+        if parent.parts.len() > 1 {
+            parent.parts.remove(parent.parts.len() - 1);
+            Some(parent)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Vec<String>> for EntityPath {
+    fn from(value: Vec<String>) -> Self {
+        Self {
+            parts: value.into_iter().map(|part| Name::new(part)).collect(),
+        }
+    }
 }
 
 /// A list of [`VariableCurve`], and the [`EntityPath`] to which they apply.

--- a/src/core/animation_clip.rs
+++ b/src/core/animation_clip.rs
@@ -67,7 +67,7 @@ impl EntityPath {
 impl From<Vec<String>> for EntityPath {
     fn from(value: Vec<String>) -> Self {
         Self {
-            parts: value.into_iter().map(|part| Name::new(part)).collect(),
+            parts: value.into_iter().map(Name::new).collect(),
         }
     }
 }

--- a/src/core/animation_graph/dot_output.rs
+++ b/src/core/animation_graph/dot_output.rs
@@ -134,7 +134,7 @@ fn write_col(
                 ParamSpec::BoneMask => String::from("󰚌"),
                 ParamSpec::Quat => String::from("󰑵"),
                 ParamSpec::Vec3 => String::from("󰵉"),
-                ParamSpec::EntityPath => String::from("EntityPath")
+                ParamSpec::EntityPath => String::from("EntityPath"),
             };
 
             write!(
@@ -221,7 +221,7 @@ impl AsDotLabel for ParamValue {
             ParamValue::Quat(q) => format!("{}", q),
             ParamValue::BoneMask(_) => "Bone Mask".to_string(),
             ParamValue::Vec3(v) => format!("{}", v),
-            ParamValue::EntityPath(p) => "EntityPath".to_string(),
+            ParamValue::EntityPath(_) => "EntityPath".to_string(),
         }
     }
 }

--- a/src/core/animation_graph/dot_output.rs
+++ b/src/core/animation_graph/dot_output.rs
@@ -134,6 +134,7 @@ fn write_col(
                 ParamSpec::BoneMask => String::from("󰚌"),
                 ParamSpec::Quat => String::from("󰑵"),
                 ParamSpec::Vec3 => String::from("󰵉"),
+                ParamSpec::EntityPath => String::from("EntityPath")
             };
 
             write!(
@@ -220,6 +221,7 @@ impl AsDotLabel for ParamValue {
             ParamValue::Quat(q) => format!("{}", q),
             ParamValue::BoneMask(_) => "Bone Mask".to_string(),
             ParamValue::Vec3(v) => format!("{}", v),
+            ParamValue::EntityPath(p) => "EntityPath".to_string(),
         }
     }
 }

--- a/src/core/animation_graph/loader.rs
+++ b/src/core/animation_graph/loader.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     prelude::{
         ExtendSkeleton, IntoBoneSpaceNode, IntoCharacterSpaceNode, ParamSpec, RotationArcNode,
-        RotationNode, SubF32,
+        RotationNode, SubF32, TwoBoneIKNode,
     },
     utils::asset_loader_error::AssetLoaderError,
 };
@@ -144,6 +144,7 @@ pub enum AnimationNodeTypeSerial {
     IntoBoneSpace,
     IntoCharacterSpace,
     ExtendSkeleton,
+    TwoBoneIK,
     Graph(String),
 }
 
@@ -204,6 +205,9 @@ impl AssetLoader for AnimationGraphLoader {
                     }
                     AnimationNodeTypeSerial::ExtendSkeleton => {
                         ExtendSkeleton::new().wrapped(&serial_node.name)
+                    }
+                    AnimationNodeTypeSerial::TwoBoneIK => {
+                        TwoBoneIKNode::new().wrapped(&serial_node.name)
                     }
                 };
                 graph.add_node(node);

--- a/src/core/animation_graph_player.rs
+++ b/src/core/animation_graph_player.rs
@@ -1,10 +1,11 @@
 use super::{
     animation_graph::{AnimationGraph, InputOverlay, TimeState, TimeUpdate},
+    context::DeferredGizmos,
     parameters::ParamValue,
-    pose::Pose,
+    pose::{BoneId, Pose},
 };
 use crate::prelude::{GraphContext, SystemResources};
-use bevy::{asset::prelude::*, ecs::prelude::*, reflect::prelude::*};
+use bevy::{asset::prelude::*, ecs::prelude::*, reflect::prelude::*, utils::HashMap};
 
 /// Animation controls
 #[derive(Component, Default, Reflect)]
@@ -15,6 +16,7 @@ pub struct AnimationGraphPlayer {
     pub(crate) elapsed: TimeState,
     pub(crate) pending_update: Option<TimeUpdate>,
     pub(crate) context: GraphContext,
+    pub(crate) deferred_gizmos: DeferredGizmos,
 
     input_overlay: InputOverlay,
 }
@@ -28,6 +30,7 @@ impl AnimationGraphPlayer {
             elapsed: TimeState::default(),
             pending_update: None,
             context: GraphContext::default(),
+            deferred_gizmos: DeferredGizmos::default(),
 
             input_overlay: InputOverlay::default(),
         }
@@ -70,6 +73,7 @@ impl AnimationGraphPlayer {
         &mut self,
         context_tmp: &SystemResources,
         root_entity: Entity,
+        entity_map: &HashMap<BoneId, Entity>,
     ) -> Option<Pose> {
         let Some(graph_handle) = &self.animation else {
             return None;
@@ -85,6 +89,8 @@ impl AnimationGraphPlayer {
             context_tmp,
             &self.input_overlay,
             root_entity,
+            entity_map,
+            &mut self.deferred_gizmos,
         ))
     }
 

--- a/src/core/animation_node.rs
+++ b/src/core/animation_node.rs
@@ -11,7 +11,7 @@ use crate::{
         ClampF32, DivF32, ExtendSkeleton, GraphNode, IntoCharacterSpaceNode, MulF32,
         RotationArcNode, RotationNode, SubF32,
     },
-    prelude::{IntoBoneSpaceNode, IntoGlobalSpaceNode, PassContext, SpecContext},
+    prelude::{IntoBoneSpaceNode, IntoGlobalSpaceNode, PassContext, SpecContext, TwoBoneIKNode},
 };
 use bevy::{reflect::prelude::*, utils::HashMap};
 use std::{
@@ -147,6 +147,11 @@ pub enum AnimationNodeType {
     ExtendSkeleton(ExtendSkeleton),
     // ------------------------------------------------
 
+    // --- IK space conversion
+    // ------------------------------------------------
+    TwoBoneIK(TwoBoneIKNode),
+    // ------------------------------------------------
+
     // --- F32 arithmetic nodes
     // ------------------------------------------------
     AddF32(AddF32),
@@ -193,6 +198,7 @@ impl AnimationNodeType {
             AnimationNodeType::IntoCharacterSpace(n) => f(n),
             AnimationNodeType::IntoGlobalSpace(n) => f(n),
             AnimationNodeType::ExtendSkeleton(n) => f(n),
+            AnimationNodeType::TwoBoneIK(n) => f(n),
             AnimationNodeType::Custom(n) => f(n.node.lock().unwrap().deref()),
         }
     }
@@ -221,6 +227,7 @@ impl AnimationNodeType {
             AnimationNodeType::IntoCharacterSpace(n) => f(n),
             AnimationNodeType::IntoGlobalSpace(n) => f(n),
             AnimationNodeType::ExtendSkeleton(n) => f(n),
+            AnimationNodeType::TwoBoneIK(n) => f(n),
             AnimationNodeType::Custom(n) => {
                 let mut nod = n.node.lock().unwrap();
                 f(nod.deref_mut())

--- a/src/core/context/deferred_gizmos.rs
+++ b/src/core/context/deferred_gizmos.rs
@@ -1,0 +1,180 @@
+use super::PassContext;
+use crate::core::pose::BoneId;
+use bevy::{
+    gizmos::gizmos::Gizmos,
+    math::{Quat, Vec3},
+    reflect::Reflect,
+    render::color::Color,
+};
+
+#[derive(Clone)]
+pub struct DeferredGizmoRef {
+    ptr: *mut DeferredGizmos,
+}
+
+impl From<&mut DeferredGizmos> for DeferredGizmoRef {
+    fn from(value: &mut DeferredGizmos) -> Self {
+        Self { ptr: value }
+    }
+}
+impl DeferredGizmoRef {
+    #[allow(clippy::mut_from_ref)]
+    pub fn as_mut(&self) -> &mut DeferredGizmos {
+        unsafe { self.ptr.as_mut().unwrap() }
+    }
+}
+
+#[derive(Clone, Reflect, Default)]
+pub struct DeferredGizmos {
+    pub commands: Vec<DeferredGizmoCommand>,
+}
+
+impl DeferredGizmos {
+    pub fn apply(&mut self, gizmos: &mut Gizmos) {
+        for command in self.commands.drain(..) {
+            command.apply(gizmos);
+        }
+    }
+
+    pub fn sphere(&mut self, position: Vec3, rotation: Quat, radius: f32, color: Color) {
+        self.commands.push(DeferredGizmoCommand::Sphere(
+            position, rotation, radius, color,
+        ));
+    }
+
+    pub fn ray(&mut self, origin: Vec3, direction: Vec3, color: Color) {
+        self.commands
+            .push(DeferredGizmoCommand::Ray(origin, direction, color));
+    }
+}
+
+#[derive(Clone, Reflect)]
+pub enum DeferredGizmoCommand {
+    Sphere(Vec3, Quat, f32, Color),
+    Ray(Vec3, Vec3, Color),
+}
+
+impl DeferredGizmoCommand {
+    pub fn apply(self, gizmos: &mut Gizmos) {
+        match self {
+            DeferredGizmoCommand::Sphere(position, rotation, radius, color) => {
+                gizmos.sphere(position, rotation, radius, color);
+            }
+            DeferredGizmoCommand::Ray(origin, direction, color) => {
+                gizmos.ray(origin, direction, color);
+            }
+        }
+    }
+}
+
+pub trait BoneDebugGizmos {
+    fn bone_sphere(&mut self, bone_id: BoneId, radius: f32, color: Color);
+    fn bone_rays(&mut self, bone_id: BoneId);
+    fn sphere_in_parent_bone_space(
+        &mut self,
+        bone_id: BoneId,
+        position: Vec3,
+        rotation: Quat,
+        radius: f32,
+        color: Color,
+    );
+    fn ray_in_parent_bone_space(
+        &mut self,
+        bone_id: BoneId,
+        origin: Vec3,
+        direction: Vec3,
+        color: Color,
+    );
+}
+
+impl BoneDebugGizmos for PassContext<'_> {
+    fn bone_sphere(&mut self, bone_id: BoneId, radius: f32, color: Color) {
+        let entity = self.entity_map.get(&bone_id).unwrap();
+        let global_transform = self
+            .resources
+            .transform_query
+            .get(*entity)
+            .unwrap()
+            .1
+            .compute_transform();
+        self.deferred_gizmos.as_mut().sphere(
+            global_transform.translation,
+            global_transform.rotation,
+            radius,
+            color,
+        );
+    }
+
+    fn bone_rays(&mut self, bone_id: BoneId) {
+        let entity = self.entity_map.get(&bone_id).unwrap();
+        let global_transform = self
+            .resources
+            .transform_query
+            .get(*entity)
+            .unwrap()
+            .1
+            .compute_transform();
+        self.deferred_gizmos.as_mut().ray(
+            global_transform.translation,
+            global_transform.rotation * Vec3::X * 0.3,
+            Color::RED,
+        );
+        self.deferred_gizmos.as_mut().ray(
+            global_transform.translation,
+            global_transform.rotation * Vec3::Y * 0.3,
+            Color::GREEN,
+        );
+        self.deferred_gizmos.as_mut().ray(
+            global_transform.translation,
+            global_transform.rotation * Vec3::Z * 0.3,
+            Color::BLUE,
+        );
+    }
+    fn sphere_in_parent_bone_space(
+        &mut self,
+        bone_id: BoneId,
+        position: Vec3,
+        rotation: Quat,
+        radius: f32,
+        color: Color,
+    ) {
+        let parent_bone_id = bone_id.parent().unwrap();
+        let entity = self.entity_map.get(&parent_bone_id).unwrap();
+        let global_transform = self
+            .resources
+            .transform_query
+            .get(*entity)
+            .unwrap()
+            .1
+            .compute_transform();
+        self.deferred_gizmos.as_mut().sphere(
+            global_transform * position,
+            global_transform.rotation * rotation,
+            radius,
+            color,
+        );
+    }
+
+    fn ray_in_parent_bone_space(
+        &mut self,
+        bone_id: BoneId,
+        origin: Vec3,
+        direction: Vec3,
+        color: Color,
+    ) {
+        let parent_bone_id = bone_id.parent().unwrap();
+        let entity = self.entity_map.get(&parent_bone_id).unwrap();
+        let global_transform = self
+            .resources
+            .transform_query
+            .get(*entity)
+            .unwrap()
+            .1
+            .compute_transform();
+        self.deferred_gizmos.as_mut().ray(
+            global_transform * origin,
+            global_transform.rotation * direction,
+            color,
+        );
+    }
+}

--- a/src/core/context/mod.rs
+++ b/src/core/context/mod.rs
@@ -1,8 +1,10 @@
+mod deferred_gizmos;
 mod graph_context;
 mod pass_context;
 mod spec_context;
 mod system_resources;
 
+pub use deferred_gizmos::{BoneDebugGizmos, DeferredGizmos};
 pub use graph_context::GraphContext;
 pub use pass_context::PassContext;
 pub use spec_context::SpecContext;

--- a/src/core/context/pass_context.rs
+++ b/src/core/context/pass_context.rs
@@ -1,15 +1,16 @@
-use bevy::ecs::entity::Entity;
+use bevy::{ecs::entity::Entity, utils::HashMap};
 
 use crate::{
     core::{
         animation_graph::{InputOverlay, NodeId, PinId, SourcePin, TargetPin, TimeUpdate},
         duration_data::DurationData,
         frame::PoseFrame,
+        pose::BoneId,
     },
     prelude::{AnimationGraph, ParamValue},
 };
 
-use super::{GraphContext, SystemResources};
+use super::{deferred_gizmos::DeferredGizmoRef, GraphContext, SystemResources};
 
 #[derive(Clone, Copy)]
 pub struct NodeContext<'a> {
@@ -25,6 +26,8 @@ pub struct PassContext<'a> {
     pub node_context: Option<NodeContext<'a>>,
     parent: Option<PassContextRef<'a>>,
     pub root_entity: Entity,
+    pub entity_map: &'a HashMap<BoneId, Entity>,
+    pub deferred_gizmos: DeferredGizmoRef,
 }
 
 impl<'a> PassContext<'a> {
@@ -34,6 +37,8 @@ impl<'a> PassContext<'a> {
         resources: &'a SystemResources,
         overlay: &'a InputOverlay,
         root_entity: Entity,
+        entity_map: &'a HashMap<BoneId, Entity>,
+        deferred_gizmos: impl Into<DeferredGizmoRef>,
     ) -> Self {
         Self {
             context: context.into(),
@@ -42,6 +47,8 @@ impl<'a> PassContext<'a> {
             node_context: None,
             parent: None,
             root_entity,
+            entity_map,
+            deferred_gizmos: deferred_gizmos.into(),
         }
     }
 
@@ -55,6 +62,8 @@ impl<'a> PassContext<'a> {
             node_context: Some(NodeContext { node_id, graph }),
             parent: self.parent.clone(),
             root_entity: self.root_entity,
+            entity_map: self.entity_map,
+            deferred_gizmos: self.deferred_gizmos.clone(),
         }
     }
 
@@ -68,6 +77,8 @@ impl<'a> PassContext<'a> {
             node_context: None,
             parent: self.parent.clone(),
             root_entity: self.root_entity,
+            entity_map: self.entity_map,
+            deferred_gizmos: self.deferred_gizmos.clone(),
         }
     }
 
@@ -84,6 +95,8 @@ impl<'a> PassContext<'a> {
             node_context: self.node_context,
             parent: Some(self.into()),
             root_entity: self.root_entity,
+            entity_map: self.entity_map,
+            deferred_gizmos: self.deferred_gizmos.clone(),
         }
     }
 

--- a/src/core/context/system_resources.rs
+++ b/src/core/context/system_resources.rs
@@ -3,7 +3,8 @@ use bevy::{
     asset::Assets,
     core::Name,
     ecs::{prelude::*, system::SystemParam},
-    hierarchy::Children,
+    gizmos::gizmos::Gizmos,
+    hierarchy::{Children, Parent},
     transform::prelude::*,
 };
 
@@ -17,4 +18,6 @@ pub struct SystemResources<'w, 's> {
     pub transform_query: Query<'w, 's, (&'static mut Transform, &'static GlobalTransform)>,
     pub names_query: Query<'w, 's, &'static Name>,
     pub children_query: Query<'w, 's, &'static Children>,
+    pub parent_query: Query<'w, 's, &'static Parent>,
+    pub gizmos: Gizmos<'s>,
 }

--- a/src/core/frame.rs
+++ b/src/core/frame.rs
@@ -419,7 +419,7 @@ impl std::fmt::Debug for InnerPoseFrame {
     }
 }
 
-#[derive(Clone, Reflect, Debug)]
+#[derive(Clone, Reflect, Debug, Default)]
 pub struct PoseFrame {
     pub data: PoseFrameData,
     pub timestamp: f32,

--- a/src/core/parameters/core.rs
+++ b/src/core/parameters/core.rs
@@ -3,9 +3,7 @@ use bevy::{
     reflect::Reflect,
 };
 use serde::{Deserialize, Serialize};
-
-use crate::utils::unwrap::Unwrap;
-
+use crate::{utils::unwrap::Unwrap, core::animation_clip::EntityPath};
 use super::bone_mask::{BoneMask, BoneMaskSerial};
 
 #[derive(Reflect, Clone, Copy, Debug, Serialize, Deserialize)]
@@ -34,6 +32,7 @@ impl From<ParamSpec> for OptParamSpec {
 pub enum ParamSpec {
     F32,
     Vec3,
+    EntityPath,
     Quat,
     BoneMask,
 }
@@ -42,6 +41,7 @@ pub enum ParamSpec {
 pub enum ParamValue {
     F32(f32),
     Vec3(Vec3),
+    EntityPath(EntityPath),
     Quat(Quat),
     BoneMask(BoneMask),
 }
@@ -50,6 +50,7 @@ pub enum ParamValue {
 pub enum ParamValueSerial {
     F32(f32),
     Vec3(Vec3),
+    EntityPath(Vec<String>),
     Quat(Quat),
     BoneMask(BoneMaskSerial),
 }
@@ -59,6 +60,7 @@ impl From<ParamValueSerial> for ParamValue {
         match value {
             ParamValueSerial::F32(v) => ParamValue::F32(v),
             ParamValueSerial::Vec3(v) => ParamValue::Vec3(v),
+            ParamValueSerial::EntityPath(v) => ParamValue::EntityPath(v.into()),
             ParamValueSerial::Quat(v) => ParamValue::Quat(v),
             ParamValueSerial::BoneMask(v) => ParamValue::BoneMask(v.into()),
         }
@@ -70,6 +72,15 @@ impl Unwrap<f32> for ParamValue {
         match self {
             ParamValue::F32(f) => f,
             _ => panic!("Expected F32, found {:?}", ParamSpec::from(&self)),
+        }
+    }
+}
+
+impl Unwrap<EntityPath> for ParamValue {
+    fn unwrap(self) -> EntityPath {
+        match self {
+            ParamValue::EntityPath(f) => f,
+            _ => panic!("Expected EntityPath, found {:?}", ParamSpec::from(&self)),
         }
     }
 }
@@ -127,6 +138,7 @@ impl From<&ParamValue> for ParamSpec {
         match value {
             ParamValue::F32(_) => ParamSpec::F32,
             ParamValue::Vec3(_) => ParamSpec::Vec3,
+            ParamValue::EntityPath(_) => ParamSpec::EntityPath,
             ParamValue::Quat(_) => ParamSpec::Quat,
             ParamValue::BoneMask(_) => ParamSpec::BoneMask,
         }

--- a/src/core/parameters/core.rs
+++ b/src/core/parameters/core.rs
@@ -1,10 +1,10 @@
+use super::bone_mask::{BoneMask, BoneMaskSerial};
+use crate::{core::animation_clip::EntityPath, utils::unwrap::Unwrap};
 use bevy::{
     math::{Quat, Vec3},
     reflect::Reflect,
 };
 use serde::{Deserialize, Serialize};
-use crate::{utils::unwrap::Unwrap, core::animation_clip::EntityPath};
-use super::bone_mask::{BoneMask, BoneMaskSerial};
 
 #[derive(Reflect, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct OptParamSpec {

--- a/src/core/plugin.rs
+++ b/src/core/plugin.rs
@@ -3,7 +3,7 @@ use super::{
         process_animated_scenes, spawn_animated_scenes, AnimatedScene, AnimatedSceneLoader,
     },
     animation_graph::loader::{AnimationGraphLoader, GraphClipLoader},
-    systems::animation_player,
+    systems::{animation_player, animation_player_deferred_gizmos},
 };
 use crate::prelude::{AnimationGraph, AnimationGraphPlayer, GraphClip};
 use bevy::{prelude::*, transform::TransformSystem};
@@ -31,7 +31,9 @@ impl Plugin for AnimationGraphPlugin {
             .add_systems(PreUpdate, (spawn_animated_scenes, process_animated_scenes))
             .add_systems(
                 PostUpdate,
-                animation_player.before(TransformSystem::TransformPropagate),
+                (animation_player, animation_player_deferred_gizmos)
+                    .chain()
+                    .before(TransformSystem::TransformPropagate),
             );
     }
 }

--- a/src/core/space_conversion.rs
+++ b/src/core/space_conversion.rs
@@ -94,7 +94,7 @@ impl SpaceConversion for PassContext<'_> {
             };
 
             // Obtain a merged local transform frame
-            let mut local_transform_frame = ValueFrame {
+            let local_transform_frame = ValueFrame {
                 prev: *entity_transform,
                 prev_timestamp: f32::MIN,
                 next: *entity_transform,
@@ -102,33 +102,8 @@ impl SpaceConversion for PassContext<'_> {
                 prev_is_wrapped: true,
                 next_is_wrapped: true,
             };
-
-            if let Some(translation_frame) = &bone_frame.translation {
-                local_transform_frame = local_transform_frame.merge_linear(
-                    translation_frame,
-                    |transform, translation| {
-                        let mut new_transform = *transform;
-                        new_transform.translation = *translation;
-                        new_transform
-                    },
-                );
-            }
-            if let Some(rotation_frame) = &bone_frame.rotation {
-                local_transform_frame =
-                    local_transform_frame.merge_linear(rotation_frame, |transform, rotation| {
-                        let mut new_transform = *transform;
-                        new_transform.rotation = *rotation;
-                        new_transform
-                    });
-            }
-            if let Some(scale_frame) = &bone_frame.scale {
-                local_transform_frame =
-                    local_transform_frame.merge_linear(scale_frame, |transform, scale| {
-                        let mut new_transform = *transform;
-                        new_transform.scale = *scale;
-                        new_transform
-                    });
-            }
+            let local_transform_frame =
+                bone_frame.to_transform_frame_linear_with_base_frame(local_transform_frame);
 
             let character_transform_frame = parent_transform_frame
                 .merge_linear(&local_transform_frame, |parent, child| *child * *parent);
@@ -240,7 +215,7 @@ impl SpaceConversion for PassContext<'_> {
             };
 
             // Obtain a merged character transform frame
-            let mut character_transform_frame = ValueFrame {
+            let character_transform_frame = ValueFrame {
                 prev: *entity_transform,
                 prev_timestamp: f32::MIN,
                 next: *entity_transform,
@@ -250,34 +225,8 @@ impl SpaceConversion for PassContext<'_> {
             }
             .merge_linear(&parent_transform_frame, |child, parent| *child * *parent);
 
-            if let Some(translation_frame) = &bone_frame.translation {
-                character_transform_frame = character_transform_frame.merge_linear(
-                    translation_frame,
-                    |transform, translation| {
-                        let mut new_transform = *transform;
-                        new_transform.translation = *translation;
-                        new_transform
-                    },
-                );
-            }
-            if let Some(rotation_frame) = &bone_frame.rotation {
-                character_transform_frame = character_transform_frame.merge_linear(
-                    rotation_frame,
-                    |transform, rotation| {
-                        let mut new_transform = *transform;
-                        new_transform.rotation = *rotation;
-                        new_transform
-                    },
-                );
-            }
-            if let Some(scale_frame) = &bone_frame.scale {
-                character_transform_frame =
-                    character_transform_frame.merge_linear(scale_frame, |transform, scale| {
-                        let mut new_transform = *transform;
-                        new_transform.scale = *scale;
-                        new_transform
-                    });
-            }
+            let character_transform_frame =
+                bone_frame.to_transform_frame_linear_with_base_frame(character_transform_frame);
 
             let bone_transform_frame = parent_inverse_transform_frame
                 .merge_linear(&character_transform_frame, |parent, child| *child * *parent);

--- a/src/nodes/clip_node.rs
+++ b/src/nodes/clip_node.rs
@@ -50,7 +50,9 @@ impl NodeLike for ClipNode {
 
     fn pose_pass(&self, time_update: TimeUpdate, ctx: PassContext) -> Option<PoseFrame> {
         let clip_duration = self.clip_duration(&ctx);
-        let clip = ctx.resources.graph_clip_assets.get(&self.clip).unwrap();
+        let Some(clip) = ctx.resources.graph_clip_assets.get(&self.clip) else {
+            return Some(PoseFrame::default());
+        };
 
         let prev_time = ctx.prev_time_fwd();
         let time = time_update.apply(prev_time);

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -9,6 +9,7 @@ pub mod loop_node;
 pub mod rotation_node;
 pub mod space_conversion;
 pub mod speed_node;
+pub mod twoboneik_node;
 
 pub use arithmetic::*;
 pub use blend_node::*;
@@ -21,3 +22,4 @@ pub use loop_node::*;
 pub use rotation_node::*;
 pub use space_conversion::*;
 pub use speed_node::*;
+pub use twoboneik_node::*;

--- a/src/nodes/twoboneik_node.rs
+++ b/src/nodes/twoboneik_node.rs
@@ -140,6 +140,7 @@ impl NodeLike for TwoBoneIKNode {
     }
 }
 
+// Adapted from https://blog.littlepolygon.com/posts/twobone/
 fn two_bone_ik(
     bone: Transform,
     parent: Transform,

--- a/src/nodes/twoboneik_node.rs
+++ b/src/nodes/twoboneik_node.rs
@@ -10,7 +10,7 @@ use crate::{
         animation_graph::{PinId, TimeUpdate},
         animation_node::{AnimationNode, AnimationNodeType, NodeLike},
         duration_data::DurationData,
-        frame::{CharacterPoseFrame, PoseFrame, PoseFrameData, PoseSpec},
+        frame::{CharacterPoseFrame, PoseFrame, PoseFrameData, PoseSpec, BonePoseFrame},
     },
     prelude::{OptParamSpec, ParamSpec, PassContext, SampleLinearAt, SpecContext},
     utils::unwrap::Unwrap,
@@ -44,15 +44,14 @@ impl NodeLike for TwoBoneIKNode {
         let targetposition: Vec3 = ctx.parameter_back(Self::TARGETPOS).unwrap();
         //let targetrotation: Quat = ctx.parameter_back(Self::TARGETROT).unwrap();
         let pose = ctx.pose_back(Self::INPUT, input);
-        let mut character_pose_data: CharacterPoseFrame = pose.data.unwrap();
-        let mut inner_pose_data = character_pose_data.inner_mut();
+        let mut bone_pose_data: BonePoseFrame = pose.data.unwrap();
+        let mut inner_pose_data = bone_pose_data.inner_mut();
 
         for (bone_path, bone_id) in inner_pose_data.paths.iter() {
             if *bone_path == target {
                 let bone = inner_pose_data.bones[*bone_id].clone();
                 if let Some(parent_path) = bone_path.parent() {
                     if let Some(grandparent_path) = parent_path.parent() {
-                        // TODO : get global or character frame of reference values
                         // NOTE : targetposition and rotation need to be in the frame of reference used for that
                         // a is gp, b is p, c is target bones current state, t is target state
                         let parent_id = inner_pose_data.paths.get(&parent_path).unwrap();
@@ -72,38 +71,42 @@ impl NodeLike for TwoBoneIKNode {
                         let bone_frame = bone.to_transform_frame_linear();
                         let bone_transform = bone_frame.sample_linear_at(pose.timestamp);
 
+                        // TODO : transform the local space to grandparent space for the calculations
+                        let parent_gp_transform = grandparent_transform * parent_transform;
+                        let bone_gp_transform = parent_gp_transform * bone_transform;
+
                         let eps = 0.01;
-                        let length_gp_p = (parent_transform.translation
+                        let length_gp_p = (parent_gp_transform.translation
                             - grandparent_transform.translation)
                             .length();
                         let length_targetcurr_p =
-                            (parent_transform.translation - bone_transform.translation).length();
+                            (parent_gp_transform.translation - bone_gp_transform.translation).length();
                         let length_gp_target = (targetposition - grandparent_transform.translation)
                             .length()
                             .clamp(eps, length_gp_p + length_targetcurr_p - eps);
 
                         //get current interior angles
-                        let curr_gp_int = (bone_transform.translation
+                        let curr_gp_int = (bone_gp_transform.translation
                             - grandparent_transform.translation)
                             .normalize()
                             .dot(
-                                (parent_transform.translation - grandparent_transform.translation)
+                                (parent_gp_transform.translation - grandparent_transform.translation)
                                     .normalize(),
                             )
                             .clamp(-1., 1.)
                             .acos();
 
                         let curr_p_int = (grandparent_transform.translation
-                            - parent_transform.translation)
+                            - parent_gp_transform.translation)
                             .normalize()
                             .dot(
-                                (bone_transform.translation - parent_transform.translation)
+                                (bone_gp_transform.translation - parent_gp_transform.translation)
                                     .normalize(),
                             )
                             .clamp(-1., 1.)
                             .acos();
 
-                        let curr_gp_target_int = (bone_transform.translation
+                        let curr_gp_target_int = (bone_gp_transform.translation
                             - grandparent_transform.translation)
                             .normalize()
                             .dot((targetposition - grandparent_transform.translation).normalize())
@@ -122,20 +125,21 @@ impl NodeLike for TwoBoneIKNode {
                                 .clamp(-1., 1.)
                                 .acos();
 
-                        // rotation axis and angles, gr are global rotations: TODO : global rotation
-                        let axis0 = (bone_transform.translation
+                        // rotation axis and angles, gr are global rotations
+                        // TODO check with formula
+                        let axis0 = (bone_gp_transform.translation
                             - grandparent_transform.translation.cross(
-                                parent_transform.translation - grandparent_transform.translation,
+                                parent_gp_transform.translation - grandparent_transform.translation,
                             ))
                         .normalize();
 
-                        let axis1 = (bone_transform.translation
+                        let axis1 = (bone_gp_transform.translation
                             - grandparent_transform.translation)
                             .cross(targetposition - grandparent_transform.translation)
                             .normalize();
 
-                        let inverse_gp_global = Quat::IDENTITY;
-                        let inverse_p_global = parent_transform.rotation.inverse();
+                        let inverse_gp_global = grandparent_transform.rotation.inverse();
+                        let inverse_p_global = parent_gp_transform.rotation.inverse();
                         let r0 = Quat::from_axis_angle(
                             (inverse_gp_global * axis0).normalize(),
                             des_gp_int - curr_gp_int,
@@ -171,7 +175,7 @@ impl NodeLike for TwoBoneIKNode {
         }
 
         Some(PoseFrame {
-            data: PoseFrameData::CharacterSpace(character_pose_data),
+            data: PoseFrameData::BoneSpace(bone_pose_data),
             timestamp: pose.timestamp,
         })
     }
@@ -184,11 +188,11 @@ impl NodeLike for TwoBoneIKNode {
     }
 
     fn pose_input_spec(&self, _: SpecContext) -> HashMap<PinId, PoseSpec> {
-        HashMap::from([(Self::INPUT.into(), PoseSpec::CharacterSpace)])
+        HashMap::from([(Self::INPUT.into(), PoseSpec::BoneSpace)])
     }
 
     fn pose_output_spec(&self, _: SpecContext) -> Option<PoseSpec> {
-        Some(PoseSpec::CharacterSpace)
+        Some(PoseSpec::BoneSpace)
     }
 
     fn display_name(&self) -> String {

--- a/src/nodes/twoboneik_node.rs
+++ b/src/nodes/twoboneik_node.rs
@@ -48,74 +48,70 @@ impl NodeLike for TwoBoneIKNode {
         let mut bone_pose_data: BonePoseFrame = pose.data.unwrap();
         let inner_pose_data = bone_pose_data.inner_mut();
 
-        for (bone_path, bone_id) in inner_pose_data.paths.iter() {
-            if *bone_path == target {
-                let bone = inner_pose_data.bones[*bone_id].clone();
-                let Some(parent_path) = bone_path.parent() else {
-                    continue;
-                };
-                let Some(grandparent_path) = parent_path.parent() else {
-                    continue;
-                };
-                let target_gp = ctx.root_to_bone_space(
-                    Transform::from_translation(target_pos_char),
-                    inner_pose_data,
-                    grandparent_path.parent().unwrap().clone(),
-                    pose.timestamp,
-                );
+        if let (Some(bone_id), Some(parent_path), Some(grandparent_path)) = (
+            inner_pose_data.paths.get(&target),
+            target.parent(),
+            target.parent().and_then(|p| p.parent()),
+        ) {
+            let bone = inner_pose_data.bones[*bone_id].clone();
+            let target_gp = ctx.root_to_bone_space(
+                Transform::from_translation(target_pos_char),
+                inner_pose_data,
+                grandparent_path.parent().unwrap().clone(),
+                pose.timestamp,
+            );
 
-                let target_pos_gp = target_gp.translation;
+            let target_pos_gp = target_gp.translation;
 
-                let parent_id = inner_pose_data.paths.get(&parent_path).unwrap();
-                let parent_frame = {
-                    let parent_bone = inner_pose_data.bones.get_mut(*parent_id).unwrap();
-                    parent_bone.to_transform_frame_linear()
-                };
-                let parent_transform = parent_frame.sample_linear_at(pose.timestamp);
+            let parent_id = inner_pose_data.paths.get(&parent_path).unwrap();
+            let parent_frame = {
+                let parent_bone = inner_pose_data.bones.get_mut(*parent_id).unwrap();
+                parent_bone.to_transform_frame_linear()
+            };
+            let parent_transform = parent_frame.sample_linear_at(pose.timestamp);
 
-                let grandparent_id = inner_pose_data.paths.get(&grandparent_path).unwrap();
-                let grandparent_bone = inner_pose_data.bones.get_mut(*grandparent_id).unwrap();
-                let grandparent_frame = grandparent_bone.to_transform_frame_linear();
-                let grandparent_transform = grandparent_frame.sample_linear_at(pose.timestamp);
+            let grandparent_id = inner_pose_data.paths.get(&grandparent_path).unwrap();
+            let grandparent_bone = inner_pose_data.bones.get_mut(*grandparent_id).unwrap();
+            let grandparent_frame = grandparent_bone.to_transform_frame_linear();
+            let grandparent_transform = grandparent_frame.sample_linear_at(pose.timestamp);
 
-                let bone_frame = bone.to_transform_frame_linear();
-                let bone_transform = bone_frame.sample_linear_at(pose.timestamp);
+            let bone_frame = bone.to_transform_frame_linear();
+            let bone_transform = bone_frame.sample_linear_at(pose.timestamp);
 
-                let parent_gp_transform = grandparent_transform * parent_transform;
-                let bone_gp_transform = parent_gp_transform * bone_transform;
+            let parent_gp_transform = grandparent_transform * parent_transform;
+            let bone_gp_transform = parent_gp_transform * bone_transform;
 
-                let (bone_gp_transform, parent_gp_transform, grandparent_transform) = two_bone_ik(
-                    bone_gp_transform,
-                    parent_gp_transform,
-                    grandparent_transform,
-                    target_pos_gp,
-                );
+            let (bone_gp_transform, parent_gp_transform, grandparent_transform) = two_bone_ik(
+                bone_gp_transform,
+                parent_gp_transform,
+                grandparent_transform,
+                target_pos_gp,
+            );
 
-                let parent_transform =
-                    Transform::from_matrix(grandparent_transform.compute_matrix().inverse())
-                        * parent_gp_transform;
-                let bone_transform =
-                    Transform::from_matrix(parent_gp_transform.compute_matrix().inverse())
-                        * bone_gp_transform;
+            let parent_transform =
+                Transform::from_matrix(grandparent_transform.compute_matrix().inverse())
+                    * parent_gp_transform;
+            let bone_transform =
+                Transform::from_matrix(parent_gp_transform.compute_matrix().inverse())
+                    * bone_gp_transform;
 
-                inner_pose_data.bones[*grandparent_id]
-                    .rotation
-                    .as_mut()
-                    .unwrap()
-                    .map_mut(|_| grandparent_transform.rotation);
+            inner_pose_data.bones[*grandparent_id]
+                .rotation
+                .as_mut()
+                .unwrap()
+                .map_mut(|_| grandparent_transform.rotation);
 
-                inner_pose_data.bones[*parent_id]
-                    .rotation
-                    .as_mut()
-                    .unwrap()
-                    .map_mut(|_| parent_transform.rotation);
+            inner_pose_data.bones[*parent_id]
+                .rotation
+                .as_mut()
+                .unwrap()
+                .map_mut(|_| parent_transform.rotation);
 
-                inner_pose_data.bones[*bone_id]
-                    .rotation
-                    .as_mut()
-                    .unwrap()
-                    .map_mut(|_| bone_transform.rotation);
-            }
+            inner_pose_data.bones[*bone_id]
+                .rotation
+                .as_mut()
+                .unwrap()
+                .map_mut(|_| bone_transform.rotation);
         }
 
         Some(PoseFrame {

--- a/src/nodes/twoboneik_node.rs
+++ b/src/nodes/twoboneik_node.rs
@@ -1,0 +1,197 @@
+use bevy::{
+    math::{Quat, Vec3},
+    reflect::Reflect,
+    utils::HashMap,
+};
+
+use crate::{
+    core::{
+        animation_clip::EntityPath,
+        animation_graph::{PinId, TimeUpdate},
+        animation_node::{AnimationNode, AnimationNodeType, NodeLike},
+        duration_data::DurationData,
+        frame::{CharacterPoseFrame, PoseFrame, PoseFrameData, PoseSpec},
+    },
+    prelude::{OptParamSpec, ParamSpec, PassContext, SampleLinearAt, SpecContext},
+    utils::unwrap::Unwrap,
+};
+
+#[derive(Reflect, Clone, Debug, Default)]
+pub struct TwoBoneIKNode {}
+
+impl TwoBoneIKNode {
+    pub const INPUT: &'static str = "Pose In";
+    pub const TARGETBONE: &'static str = "Target Path";
+    pub const TARGETPOS: &'static str = "Target Position";
+    pub const TARGETROT: &'static str = "Target rotation of the target bone";
+
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn wrapped(self, name: impl Into<String>) -> AnimationNode {
+        AnimationNode::new_from_nodetype(name.into(), AnimationNodeType::TwoBoneIK(self))
+    }
+}
+
+impl NodeLike for TwoBoneIKNode {
+    fn duration_pass(&self, mut ctx: PassContext) -> Option<DurationData> {
+        Some(ctx.duration_back(Self::INPUT))
+    }
+
+    fn pose_pass(&self, input: TimeUpdate, mut ctx: PassContext) -> Option<PoseFrame> {
+        let target: EntityPath = ctx.parameter_back(Self::TARGETBONE).unwrap();
+        let targetposition: Vec3 = ctx.parameter_back(Self::TARGETPOS).unwrap();
+        //let targetrotation: Quat = ctx.parameter_back(Self::TARGETROT).unwrap();
+        let pose = ctx.pose_back(Self::INPUT, input);
+        let mut character_pose_data: CharacterPoseFrame = pose.data.unwrap();
+        let mut inner_pose_data = character_pose_data.inner_mut();
+
+        for (bone_path, bone_id) in inner_pose_data.paths.iter() {
+            if *bone_path == target {
+                let bone = inner_pose_data.bones[*bone_id].clone();
+                if let Some(parent_path) = bone_path.parent() {
+                    if let Some(grandparent_path) = parent_path.parent() {
+                        // TODO : get global or character frame of reference values
+                        // NOTE : targetposition and rotation need to be in the frame of reference used for that
+                        // a is gp, b is p, c is target bones current state, t is target state
+                        let parent_id = inner_pose_data.paths.get(&parent_path).unwrap();
+                        let parent_frame = {
+                            let parent_bone = inner_pose_data.bones.get_mut(*parent_id).unwrap();
+                            parent_bone.to_transform_frame_linear()
+                        };
+                        let mut parent_transform = parent_frame.sample_linear_at(pose.timestamp);
+
+                        let grandparent_id = inner_pose_data.paths.get(&grandparent_path).unwrap();
+                        let grandparent_bone =
+                            inner_pose_data.bones.get_mut(*grandparent_id).unwrap();
+                        let grandparent_frame = grandparent_bone.to_transform_frame_linear();
+                        let mut grandparent_transform =
+                            grandparent_frame.sample_linear_at(pose.timestamp);
+
+                        let bone_frame = bone.to_transform_frame_linear();
+                        let bone_transform = bone_frame.sample_linear_at(pose.timestamp);
+
+                        let eps = 0.01;
+                        let length_gp_p = (parent_transform.translation
+                            - grandparent_transform.translation)
+                            .length();
+                        let length_targetcurr_p =
+                            (parent_transform.translation - bone_transform.translation).length();
+                        let length_gp_target = (targetposition - grandparent_transform.translation)
+                            .length()
+                            .clamp(eps, length_gp_p + length_targetcurr_p - eps);
+
+                        //get current interior angles
+                        let curr_gp_int = (bone_transform.translation
+                            - grandparent_transform.translation)
+                            .normalize()
+                            .dot(
+                                (parent_transform.translation - grandparent_transform.translation)
+                                    .normalize(),
+                            )
+                            .clamp(-1., 1.)
+                            .acos();
+
+                        let curr_p_int = (grandparent_transform.translation
+                            - parent_transform.translation)
+                            .normalize()
+                            .dot(
+                                (bone_transform.translation - parent_transform.translation)
+                                    .normalize(),
+                            )
+                            .clamp(-1., 1.)
+                            .acos();
+
+                        let curr_gp_target_int = (bone_transform.translation
+                            - grandparent_transform.translation)
+                            .normalize()
+                            .dot((targetposition - grandparent_transform.translation).normalize())
+                            .clamp(-1., 1.)
+                            .acos();
+
+                        // get desired interior angles
+                        let des_gp_int = (length_targetcurr_p * length_targetcurr_p
+                            - length_gp_p * length_gp_p
+                            - length_gp_target * length_gp_target)
+                            / (-2. * length_gp_p * length_gp_target).clamp(-1., 1.).acos();
+                        let des_p_int = (length_gp_target * length_gp_target
+                            - length_gp_p * length_gp_p
+                            - length_targetcurr_p * length_targetcurr_p)
+                            / (-2. * length_gp_p * length_targetcurr_p)
+                                .clamp(-1., 1.)
+                                .acos();
+
+                        // rotation axis and angles, gr are global rotations: TODO : global rotation
+                        let axis0 = (bone_transform.translation
+                            - grandparent_transform.translation.cross(
+                                parent_transform.translation - grandparent_transform.translation,
+                            ))
+                        .normalize();
+
+                        let axis1 = (bone_transform.translation
+                            - grandparent_transform.translation)
+                            .cross(targetposition - grandparent_transform.translation)
+                            .normalize();
+
+                        let inverse_gp_global = Quat::IDENTITY;
+                        let inverse_p_global = parent_transform.rotation.inverse();
+                        let r0 = Quat::from_axis_angle(
+                            (inverse_gp_global * axis0).normalize(),
+                            des_gp_int - curr_gp_int,
+                        );
+                        let r1 = Quat::from_axis_angle(
+                            (inverse_p_global * axis0).normalize(),
+                            des_p_int - curr_p_int,
+                        );
+
+                        let r2 = Quat::from_axis_angle(
+                            (inverse_gp_global * axis1).normalize(),
+                            curr_gp_target_int,
+                        );
+
+                        // set grandparent and parent rotations
+                        grandparent_transform.rotation = grandparent_transform.rotation * (r0 * r2);
+                        parent_transform.rotation = parent_transform.rotation * r1;
+
+                        grandparent_bone
+                            .rotation
+                            .as_mut()
+                            .unwrap()
+                            .map_mut(|_| grandparent_transform.rotation);
+
+                        inner_pose_data.bones[*parent_id]
+                            .rotation
+                            .as_mut()
+                            .unwrap()
+                            .map_mut(|_| parent_transform.rotation);
+                    }
+                }
+            }
+        }
+
+        Some(PoseFrame {
+            data: PoseFrameData::CharacterSpace(character_pose_data),
+            timestamp: pose.timestamp,
+        })
+    }
+
+    fn parameter_input_spec(&self, _: SpecContext) -> HashMap<PinId, OptParamSpec> {
+        HashMap::from([
+            (Self::TARGETBONE.into(), ParamSpec::EntityPath.into()),
+            (Self::TARGETPOS.into(), ParamSpec::Vec3.into()),
+        ])
+    }
+
+    fn pose_input_spec(&self, _: SpecContext) -> HashMap<PinId, PoseSpec> {
+        HashMap::from([(Self::INPUT.into(), PoseSpec::CharacterSpace)])
+    }
+
+    fn pose_output_spec(&self, _: SpecContext) -> Option<PoseSpec> {
+        Some(PoseSpec::CharacterSpace)
+    }
+
+    fn display_name(&self) -> String {
+        "TwoBoneIK".into()
+    }
+}


### PR DESCRIPTION
### Objective

Inverse kinematics is often used in game development for procedural animations or fine-tuning existing animations to fit the circumstance (e.g. make the hands correctly grip a weapon, or place the feet at ground height) among other reasons.
The special case for inverse kinematics for two-bone chains fit most common use-cases, and is easiest to implement as it has a simple analytical solution.

### Solution

Implement a two-bone IK node, which works on bone-space poses (this helps when applying it to bones that has descendants). This node accepts a pose, a bone target and a target position, and modifies the bone target, and its two nearest ancestors in order to place the bone target at the target position while keeping bone lengths constant.

Deferred rendering gizmos were added as a way to enable easier debugging of nodes. These gizmos are buffered and rendered by a system that runs after the animation graph is evaluated.