### PR TITLE
Parallelize animation players

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_graph"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bevy",
  "indexmap 2.2.1",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_graph_editor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",

--- a/crates/bevy_animation_graph/src/core/systems.rs
+++ b/crates/bevy_animation_graph/src/core/systems.rs
@@ -123,17 +123,19 @@ pub fn animation_player(
     mut animation_players: Query<(Entity, Option<&Parent>, &mut AnimationGraphPlayer)>,
     sysres: SystemResources,
 ) {
-    for (root, maybe_parent, player) in &mut animation_players {
-        run_animation_player(
-            root,
-            player,
-            &time,
-            &morphs,
-            maybe_parent,
-            &parents,
-            &sysres,
-        );
-    }
+    animation_players
+        .par_iter_mut()
+        .for_each(|(root, maybe_parent, player)| {
+            run_animation_player(
+                root,
+                player,
+                &time,
+                &morphs,
+                maybe_parent,
+                &parents,
+                &sysres,
+            );
+        });
 }
 
 /// System that will draw deferred gizmo commands called during graph evaluation


### PR DESCRIPTION
Animation player parallel processing was disabled temporarily while I figured out how to properly handle the `PassContext`, but it can be reenabled now.