### PR TITLE
Improve example default parameters

### DIFF
--- a/crates/bevy_animation_graph/src/core/animation_graph/core.rs
+++ b/crates/bevy_animation_graph/src/core/animation_graph/core.rs
@@ -670,9 +670,7 @@ impl AnimationGraph {
             }
             SourcePin::InputParameter(pin_id) => {
                 let out = if ctx.has_parent() {
-                    ctx.parent()
-                        .parameter_back(pin_id)
-                        .map_or_else(|_| None, Some)
+                    ctx.parent().parameter_back(pin_id).ok()
                 } else {
                     None
                 }

--- a/examples/human_ik/examples/human_ik.rs
+++ b/examples/human_ik/examples/human_ik.rs
@@ -1,11 +1,9 @@
 extern crate bevy;
 extern crate bevy_animation_graph;
-extern crate bevy_inspector_egui;
 
 use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 use bevy_animation_graph::core::animated_scene::{AnimatedSceneBundle, AnimatedSceneInstance};
 use bevy_animation_graph::prelude::*;
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use std::f32::consts::PI;
 
 fn main() {
@@ -15,14 +13,29 @@ fn main() {
             ..default()
         }))
         .add_plugins(AnimationGraphPlugin)
-        .add_plugins(WorldInspectorPlugin::new())
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 0.1,
         })
+        .insert_resource(Params::default())
         .add_systems(Startup, setup)
         .add_systems(Update, keyboard_animation_control)
         .run();
+}
+
+#[derive(Resource)]
+struct Params {
+    pub speed: f32,
+    pub direction: Vec3,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            speed: 1.0,
+            direction: Vec3::Z,
+        }
+    }
 }
 
 #[derive(Component)]
@@ -79,14 +92,14 @@ fn setup(
     println!("\tSPACE: Play/Pause animation");
     println!("\tR: Reset animation");
     println!("\tUp/Down: Increase/decrease movement speed");
+    println!("\tLeft/Right: Rotate character");
 }
 
 fn keyboard_animation_control(
     keyboard_input: Res<Input<KeyCode>>,
     human_character: Query<&AnimatedSceneInstance, With<Human>>,
     mut animation_players: Query<&mut AnimationGraphPlayer>,
-    mut velocity: Local<f32>,
-    mut direction: Local<Vec3>,
+    mut params: ResMut<Params>,
     time: Res<Time>,
 ) {
     let Ok(AnimatedSceneInstance { player_entity }) = human_character.get_single() else {
@@ -109,23 +122,25 @@ fn keyboard_animation_control(
     }
 
     if keyboard_input.pressed(KeyCode::Up) {
-        *velocity += 0.5 * time.delta_seconds();
+        params.speed += 0.5 * time.delta_seconds();
     }
     if keyboard_input.pressed(KeyCode::Down) {
-        *velocity -= 0.5 * time.delta_seconds();
+        params.speed -= 0.5 * time.delta_seconds();
     }
 
-    if *direction == Vec3::ZERO {
-        *direction = Vec3::Z;
+    if params.direction == Vec3::ZERO {
+        params.direction = Vec3::Z;
     }
 
     if keyboard_input.pressed(KeyCode::Right) {
-        *direction = (Quat::from_rotation_y(1. * time.delta_seconds()) * *direction).normalize();
+        params.direction =
+            (Quat::from_rotation_y(1. * time.delta_seconds()) * params.direction).normalize();
     }
     if keyboard_input.pressed(KeyCode::Left) {
-        *direction = (Quat::from_rotation_y(-1. * time.delta_seconds()) * *direction).normalize();
+        params.direction =
+            (Quat::from_rotation_y(-1. * time.delta_seconds()) * params.direction).normalize();
     }
 
-    player.set_input_parameter("Target Speed", (*velocity).into());
-    player.set_input_parameter("Target Direction", (*direction).into());
+    player.set_input_parameter("Target Speed", params.speed.into());
+    player.set_input_parameter("Target Direction", params.direction.into());
 }


### PR DESCRIPTION
Currently examples start with a default playback speed of 0. This can make it seem as if the example does not work, which creates confusion.

This PR sets the default speed to 1.0 in both human examples, so that the character is not static on spawn.

Fixes #35 