### PR TITLE
Enable manual dispatch of dry run workflow.

### DIFF
--- a/.github/workflows/dry_run.yaml
+++ b/.github/workflows/dry_run.yaml
@@ -1,6 +1,8 @@
 name: DryRun
 
-on: {}
+on:
+  workflow_dispatch:
+    
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/dry_run.yaml
+++ b/.github/workflows/dry_run.yaml
@@ -9,8 +9,8 @@ env:
 
 jobs:
   # Run cargo publish pipeline as a dry run
-  dry_run:
-    name: Dry Run Publish
+  dry_run_library:
+    name: Dry Run Publish Library
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -32,5 +32,27 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo publish dry run for library
         run: cargo publish --dry-run -p bevy_animation_graph
+  dry_run_editor:
+    name: Dry Run Publish Editor
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install Dependencies
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo publish dry run for editor
         run: cargo publish --dry-run -p bevy_animation_graph_editor
+


### PR DESCRIPTION
This workflow cannot run as part of CI, as the editor crate will always pull the `crates.io` version of the `bevy_animation_graph` library crate, causing CI failures when the public API changes.