### PR TITLE
Unify all inspectors into a single tab

### DIFF
--- a/assets/animation_graphs/toplevel.animgraph.ron
+++ b/assets/animation_graphs/toplevel.animgraph.ron
@@ -1,14 +1,14 @@
 (
     nodes: [
         (
-            name: "Le big fsm",
+            name: "Locomotion FSM",
             node: Fsm("fsm/meme.fsm.ron"),
         ),
     ],
     edges_inverted: {
-        OutputTime: NodeTime("Le big fsm"),
-        NodeData("Le big fsm", "driver events"): InputData("les eventos"),
-        OutputData("pose"): NodeData("Le big fsm", "pose"),
+        OutputTime: NodeTime("Locomotion FSM"),
+        OutputData("pose"): NodeData("Locomotion FSM", "pose"),
+        NodeData("Locomotion FSM", "driver events"): InputData("les eventos"),
     },
     default_parameters: {
         "les eventos": EventQueue((
@@ -30,7 +30,7 @@
     output_time: Some(()),
     extra: (
         node_positions: {
-            "Le big fsm": (467.3684, 642.7369),
+            "Locomotion FSM": (447.06067, 482.12152),
         },
         input_position: (192.0, 475.0),
         output_position: (727.0, 463.0),

--- a/crates/bevy_animation_graph_editor/src/egui_fsm/lib.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_fsm/lib.rs
@@ -80,6 +80,9 @@ pub struct FrameState {
     graph_changes: Vec<EguiFsmChange>,
 
     nodes_tmp: HashMap<usize, Node>,
+    /// Whether the node got clicked in this frame
+    just_selected_node: bool,
+    just_selected_transition: bool,
 }
 
 /// The settings that are used by the node editor context
@@ -109,6 +112,8 @@ impl FrameState {
         Option::take(&mut self.active_pin);
 
         self.graph_changes.clear();
+        self.just_selected_node = false;
+        self.just_selected_transition = false;
     }
 
     pub fn canvas_origin_screen_space(&self) -> egui::Vec2 {
@@ -354,6 +359,13 @@ impl FsmUiContext {
     /// List of changes that occurred to the graph during frame
     pub fn get_changes(&self) -> &Vec<EguiFsmChange> {
         &self.frame_state.graph_changes
+    }
+
+    pub fn is_node_just_selected(&self) -> bool {
+        self.frame_state.just_selected_node
+    }
+    pub fn is_transition_just_selected(&self) -> bool {
+        self.frame_state.just_selected_transition
     }
 }
 
@@ -1024,6 +1036,7 @@ impl FsmUiContext {
         self.state.selected_node_indices.clear();
         self.state.selected_link_indices.clear();
         self.state.selected_link_indices.push(idx);
+        self.frame_state.just_selected_transition = true;
     }
 
     fn find_duplicate_link(&self, start_pin_idx: usize, end_pin_idx: usize) -> Option<usize> {
@@ -1047,6 +1060,7 @@ impl FsmUiContext {
             self.state.selected_node_indices.clear();
             self.state.selected_link_indices.clear();
             self.state.selected_node_indices.push(idx);
+            self.frame_state.just_selected_node = true;
 
             if let Some(depth_idx) = self.state.node_depth_order.iter().position(|x| *x == idx) {
                 let id = self.state.node_depth_order.remove(depth_idx);

--- a/crates/bevy_animation_graph_editor/src/egui_nodes/lib.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_nodes/lib.rs
@@ -82,6 +82,7 @@ pub struct FrameState {
 
     pins_tmp: HashMap<usize, Pin>,
     nodes_tmp: HashMap<usize, Node>,
+    just_selected_node: bool,
 }
 
 /// The settings that are used by the node editor context
@@ -112,6 +113,7 @@ impl FrameState {
         Option::take(&mut self.active_pin);
 
         self.graph_changes.clear();
+        self.just_selected_node = false;
     }
 
     pub fn canvas_origin_screen_space(&self) -> egui::Vec2 {
@@ -520,6 +522,10 @@ impl NodesContext {
     #[allow(dead_code)]
     pub fn get_node_dimensions(&self, id: usize) -> Option<egui::Vec2> {
         self.nodes.get(&id).map(|n| n.state.rect.size())
+    }
+
+    pub fn is_node_just_selected(&self) -> bool {
+        self.frame_state.just_selected_node
     }
 }
 
@@ -1424,6 +1430,7 @@ impl NodesContext {
             self.state.selected_node_indices.clear();
             self.state.selected_link_indices.clear();
             self.state.selected_node_indices.push(idx);
+            self.frame_state.just_selected_node = true;
 
             if let Some(depth_idx) = self.state.node_depth_order.iter().position(|x| *x == idx) {
                 let id = self.state.node_depth_order.remove(depth_idx);

--- a/crates/bevy_animation_graph_editor/src/ui.rs
+++ b/crates/bevy_animation_graph_editor/src/ui.rs
@@ -76,7 +76,7 @@ pub enum InspectorSelection {
     Graph,
     /// The selection data is contained in the FsmSelection, not here. This is because the FSM
     /// should not become unselected whenever the inspector window shows something else.
-    FSM,
+    Fsm,
     #[default]
     Nothing,
 }
@@ -298,7 +298,7 @@ impl egui_dock::TabViewer for TabViewer<'_> {
                 InspectorSelection::Graph => {
                     Self::graph_inspector(self.world, ui, self.selection, self.graph_changes)
                 }
-                InspectorSelection::FSM => {
+                InspectorSelection::Fsm => {
                     Self::fsm_inspector(self.world, ui, self.selection, self.global_changes)
                 }
             },
@@ -796,7 +796,7 @@ impl TabViewer<'_> {
                 state_creation: State::default(),
                 transition_creation: Transition::default(),
             });
-            selection.inspector_selection = InspectorSelection::FSM;
+            selection.inspector_selection = InspectorSelection::Fsm;
         }
     }
 


### PR DESCRIPTION
With the addition of animation state machines, the number of different inspector tabs was getting a bit ridiculous. Rather than have a separate tab per kind of inspector, this PR adopts the approach taken by most modern editors where only an "active" inspector is shown, generally for the last thing you clicked.