### PR TITLE
Dedicated user event API and editor UI

### DIFF
--- a/assets/animation_graphs/toplevel.animgraph.ron
+++ b/assets/animation_graphs/toplevel.animgraph.ron
@@ -2,16 +2,17 @@
     nodes: [
         (
             name: "Locomotion FSM",
-            node: Fsm("fsm/meme.fsm.ron"),
+            node: Fsm("fsm/locomotion.fsm.ron"),
         ),
     ],
     edges_inverted: {
-        OutputTime: NodeTime("Locomotion FSM"),
         OutputData("pose"): NodeData("Locomotion FSM", "pose"),
-        NodeData("Locomotion FSM", "driver events"): InputData("les eventos"),
+        NodeData("Locomotion FSM", "driver events"): InputData("user events"),
+        NodeData("Locomotion FSM", "speed"): InputData("speed"),
+        OutputTime: NodeTime("Locomotion FSM"),
     },
     default_parameters: {
-        "les eventos": EventQueue((
+        "user events": EventQueue((
             events: [
                 (
                     event: (
@@ -22,6 +23,7 @@
                 ),
             ],
         )),
+        "speed": F32(2.0),
     },
     input_times: {},
     output_parameters: {
@@ -30,9 +32,9 @@
     output_time: Some(()),
     extra: (
         node_positions: {
-            "Locomotion FSM": (447.06067, 482.12152),
+            "Locomotion FSM": (463.6761, 488.58313),
         },
-        input_position: (192.0, 475.0),
+        input_position: (237.51926, 497.61542),
         output_position: (727.0, 463.0),
     ),
 )

--- a/assets/fsm/locomotion.fsm.ron
+++ b/assets/fsm/locomotion.fsm.ron
@@ -11,14 +11,14 @@
     ],
     transitions: [
         (
-            id: "run_to_walk",
+            id: "slow_down",
             source: "run",
             target: "walk",
             duration: 1.0,
             graph: "animation_graphs/walk_to_run.animgraph.ron",
         ),
         (
-            id: "walk_to_run",
+            id: "speed_up",
             source: "walk",
             target: "run",
             duration: 1.0,
@@ -26,11 +26,14 @@
         ),
     ],
     start_state: "run",
+    input_data: {
+        "speed": F32(1.0),
+    },
     extra: (
         states: {
-            "run": (335.3684, 522.9473),
-            "walk": (334.10522, 310.10526),
             "kaput useless stateeeeeeeee reeeeee REEEE": (207.1579, 350.5263),
+            "walk": (334.10522, 310.10526),
+            "run": (554.1376, 309.71655),
         },
     ),
 )

--- a/crates/bevy_animation_graph/src/core/state_machine/high_level/loader.rs
+++ b/crates/bevy_animation_graph/src/core/state_machine/high_level/loader.rs
@@ -25,6 +25,7 @@ impl AssetLoader for StateMachineLoader {
             let serial: StateMachineSerial = ron::de::from_bytes(&bytes)?;
             let mut fsm = StateMachine {
                 extra: serial.extra,
+                input_data: serial.input_data,
                 ..Default::default()
             };
 

--- a/crates/bevy_animation_graph/src/core/state_machine/high_level/serial.rs
+++ b/crates/bevy_animation_graph/src/core/state_machine/high_level/serial.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::core::{animation_graph::PinMap, edge_data::DataValue};
+
 use super::{Extra, State, StateMachine, Transition};
 
 pub type StateIdSerial = String;
@@ -25,6 +27,8 @@ pub struct StateMachineSerial {
     pub states: Vec<StateSerial>,
     pub transitions: Vec<TransitionSerial>,
     pub start_state: String,
+    #[serde(default)]
+    pub input_data: PinMap<DataValue>,
     #[serde(default)]
     pub extra: Extra,
 }
@@ -61,6 +65,7 @@ impl From<&StateMachine> for StateMachineSerial {
                 .collect(),
             start_state: value.start_state.clone(),
             extra: value.extra.clone(),
+            input_data: value.input_data.clone(),
         }
     }
 }

--- a/crates/bevy_animation_graph_editor/src/ui.rs
+++ b/crates/bevy_animation_graph_editor/src/ui.rs
@@ -583,11 +583,7 @@ impl TabViewer<'_> {
                             if ui.button(ev).clicked() {
                                 graph_player.send_event(AnimationEvent { id: ev.into() });
                             }
-                            if ui.button("×").clicked() {
-                                false
-                            } else {
-                                true
-                            }
+                            ui.button("×").clicked()
                         })
                         .inner
                     })


### PR DESCRIPTION
Currently, sending events into a graph from gameplay logic require manually adding an `EventQueue` input parameter through the animation graph player, and adding your event there. However, such a parameter would not get cleared every frame, so it would send the same events every frame until manually cleared.

This PR adds a `send_event` API to the animation graph player that enables sending a single event that will get cleared at the end of the frame. It also adds some cleaner UI for sending events from the editor (for testing purposes), which allows you to save a few event types so that you can send them with a single click.