### PR TITLE
Add a new blend sync mode option, fix speed node

### DIFF
--- a/crates/bevy_animation_graph/src/core/animation_graph/loader.rs
+++ b/crates/bevy_animation_graph/src/core/animation_graph/loader.rs
@@ -134,8 +134,8 @@ impl AssetLoader for AnimationGraphLoader {
                     *override_interpolation,
                 )
                 .wrapped(&serial_node.name),
-                AnimationNodeTypeSerial::Blend { mode } => {
-                    BlendNode::new(*mode).wrapped(&serial_node.name)
+                AnimationNodeTypeSerial::Blend { mode, sync_mode } => {
+                    BlendNode::new(*mode, *sync_mode).wrapped(&serial_node.name)
                 }
                 AnimationNodeTypeSerial::Chain {
                     interpolation_period,

--- a/crates/bevy_animation_graph/src/core/animation_graph/serial.rs
+++ b/crates/bevy_animation_graph/src/core/animation_graph/serial.rs
@@ -2,7 +2,7 @@ use super::{pin, AnimationGraph, Extra};
 use crate::{
     core::{animation_clip::Interpolation, edge_data::AnimationEvent},
     flipping::config::FlipConfig,
-    nodes::{BlendMode, ChainDecay, CompareOp, RotationMode, RotationSpace},
+    nodes::{BlendMode, BlendSyncMode, ChainDecay, CompareOp, RotationMode, RotationSpace},
     prelude::{AnimationNode, AnimationNodeType, DataSpec, DataValue},
     utils::ordered_map::OrderedMap,
 };
@@ -62,6 +62,8 @@ pub enum AnimationNodeTypeSerial {
     Blend {
         #[serde(default)]
         mode: BlendMode,
+        #[serde(default)]
+        sync_mode: BlendSyncMode,
     },
     FlipLR {
         #[serde(default)]
@@ -162,7 +164,10 @@ impl From<&AnimationNodeType> for AnimationNodeTypeSerial {
             AnimationNodeType::Chain(n) => AnimationNodeTypeSerial::Chain {
                 interpolation_period: n.interpolation_period,
             },
-            AnimationNodeType::Blend(n) => AnimationNodeTypeSerial::Blend { mode: n.mode },
+            AnimationNodeType::Blend(n) => AnimationNodeTypeSerial::Blend {
+                mode: n.mode,
+                sync_mode: n.sync_mode,
+            },
             AnimationNodeType::FlipLR(n) => AnimationNodeTypeSerial::FlipLR {
                 config: n.config.clone(),
             },

--- a/crates/bevy_animation_graph/src/core/plugin.rs
+++ b/crates/bevy_animation_graph/src/core/plugin.rs
@@ -15,9 +15,9 @@ use super::{
     systems::{animation_player, animation_player_deferred_gizmos},
 };
 use crate::nodes::{
-    AbsF32, AddF32, BlendNode, ChainNode, ClampF32, ClipNode, CompareF32, DivF32, DummyNode,
-    FireEventNode, FlipLRNode, GraphNode, LoopNode, MulF32, PaddingNode, RotationArcNode,
-    RotationNode, SpeedNode, SubF32, TwoBoneIKNode,
+    AbsF32, AddF32, BlendMode, BlendNode, BlendSyncMode, ChainNode, ClampF32, ClipNode, CompareF32,
+    DivF32, DummyNode, FireEventNode, FlipLRNode, GraphNode, LoopNode, MulF32, PaddingNode,
+    RotationArcNode, RotationNode, SpeedNode, SubF32, TwoBoneIKNode,
 };
 use crate::prelude::{
     config::{FlipConfig, FlipNameMapper, PatternMapper, PatternMapperSerial},
@@ -87,6 +87,8 @@ impl AnimationGraphPlugin {
             .register_type::<FlipNameMapper>()
             .register_type::<PatternMapper>()
             .register_type::<PatternMapperSerial>()
+            .register_type::<BlendMode>()
+            .register_type::<BlendSyncMode>()
             .register_type::<()>()
             .register_type_data::<(), ReflectDefault>()
         // --- Node registrations

--- a/crates/bevy_animation_graph/src/nodes/speed_node.rs
+++ b/crates/bevy_animation_graph/src/nodes/speed_node.rs
@@ -45,8 +45,9 @@ impl NodeLike for SpeedNode {
         let input = ctx.time_update_fwd()?;
         let fw_upd = match input {
             TimeUpdate::Delta(dt) => TimeUpdate::Delta(dt * speed),
-            TimeUpdate::Absolute(t) => TimeUpdate::Absolute(t * speed),
+            TimeUpdate::Absolute(t) => TimeUpdate::Absolute(t),
         };
+
         ctx.set_time_update_back(Self::IN_TIME, fw_upd);
         let mut in_pose: Pose = ctx.data_back(Self::IN_POSE)?.val();
 


### PR DESCRIPTION
* Added a `blend_sync_mode` setting to the Blend node, allow users to select whether the second input should be synced to the same timestamp as the first, or no syncing should be done.
* The speed node should not be applying a speed factor for absolute timestamps