### PR TITLE
FSM global transitions

### DIFF
--- a/assets/animation_graphs/toplevel.animgraph.ron
+++ b/assets/animation_graphs/toplevel.animgraph.ron
@@ -15,9 +15,7 @@
         "user events": EventQueue((
             events: [
                 (
-                    event: (
-                        id: "",
-                    ),
+                    event: StringId(""),
                     weight: 1.0,
                     percentage: 1.0,
                 ),

--- a/assets/animation_graphs/walk_to_run.animgraph.ron
+++ b/assets/animation_graphs/walk_to_run.animgraph.ron
@@ -2,9 +2,7 @@
     nodes: [
         (
             name: "Done",
-            node: FireEvent((
-                id: "end_transition",
-            )),
+            node: FireEvent(EndTransition),
         ),
         (
             name: "Blend",

--- a/assets/fsm/locomotion.fsm.ron
+++ b/assets/fsm/locomotion.fsm.ron
@@ -3,10 +3,15 @@
         (
             id: "walk",
             graph: "animation_graphs/walk.animgraph.ron",
+            global_transition: Some((
+                duration: 1.0,
+                graph: "animation_graphs/walk_to_run.animgraph.ron",
+            )),
         ),
         (
             id: "run",
             graph: "animation_graphs/run.animgraph.ron",
+            global_transition: None,
         ),
     ],
     transitions: [
@@ -31,8 +36,8 @@
     },
     extra: (
         states: {
-            "walk": (334.10522, 310.10526),
-            "run": (554.1376, 309.71655),
+            "walk": (334.10522, 309.52664),
+            "run": (552.15, 310.6519),
         },
     ),
 )

--- a/assets/fsm/locomotion.fsm.ron
+++ b/assets/fsm/locomotion.fsm.ron
@@ -16,14 +16,14 @@
     ],
     transitions: [
         (
-            id: "slow_down",
+            id: Direct("slow_down"),
             source: "run",
             target: "walk",
             duration: 1.0,
             graph: "animation_graphs/walk_to_run.animgraph.ron",
         ),
         (
-            id: "speed_up",
+            id: Direct("speed_up"),
             source: "walk",
             target: "run",
             duration: 1.0,

--- a/crates/bevy_animation_graph/src/core/context/graph_context.rs
+++ b/crates/bevy_animation_graph/src/core/context/graph_context.rs
@@ -4,7 +4,7 @@ use crate::{
         duration_data::DurationData,
         pose::Pose,
         prelude::AnimationGraph,
-        state_machine::FSMState,
+        state_machine::low_level::FSMState,
     },
     prelude::DataValue,
 };

--- a/crates/bevy_animation_graph/src/core/context/graph_context_arena.rs
+++ b/crates/bevy_animation_graph/src/core/context/graph_context_arena.rs
@@ -1,5 +1,7 @@
 use super::GraphContext;
-use crate::core::{animation_graph::NodeId, prelude::AnimationGraph, state_machine::StateId};
+use crate::core::{
+    animation_graph::NodeId, prelude::AnimationGraph, state_machine::low_level::LowLevelStateId,
+};
 use bevy::{asset::AssetId, reflect::Reflect, utils::HashMap};
 
 #[derive(Reflect, Clone, Copy, Debug, Eq, PartialEq, Hash, Default)]
@@ -9,7 +11,7 @@ pub struct GraphContextId(usize);
 pub struct SubContextId {
     pub ctx_id: GraphContextId,
     pub node_id: NodeId,
-    pub state_id: Option<StateId>,
+    pub state_id: Option<LowLevelStateId>,
 }
 
 #[derive(Reflect, Debug)]

--- a/crates/bevy_animation_graph/src/core/context/pass_context.rs
+++ b/crates/bevy_animation_graph/src/core/context/pass_context.rs
@@ -10,7 +10,7 @@ use crate::{
         duration_data::DurationData,
         errors::GraphError,
         pose::BoneId,
-        state_machine::{LowLevelStateMachine, StateId},
+        state_machine::low_level::{LowLevelStateId, LowLevelStateMachine},
     },
     prelude::{AnimationGraph, DataValue},
 };
@@ -40,11 +40,11 @@ pub struct FsmContext<'a> {
 
 #[derive(Clone)]
 pub struct StateStack {
-    pub stack: Vec<(StateId, StateRole)>,
+    pub stack: Vec<(LowLevelStateId, StateRole)>,
 }
 
 impl StateStack {
-    pub fn last_state(&self) -> StateId {
+    pub fn last_state(&self) -> LowLevelStateId {
         self.stack.last().unwrap().0.clone()
     }
     pub fn last_role(&self) -> StateRole {
@@ -278,7 +278,7 @@ impl<'a> PassContext<'a> {
     pub fn str_ctx_stack(&self) -> String {
         let mut s = if let Some(fsm_ctx) = &self.fsm_context {
             format!(
-                "- [FSM] {}: {}",
+                "- [FSM] {}: {:?}",
                 "state_id",
                 fsm_ctx.state_stack.last_state()
             )

--- a/crates/bevy_animation_graph/src/core/edge_data/events.rs
+++ b/crates/bevy_animation_graph/src/core/edge_data/events.rs
@@ -1,11 +1,27 @@
 use bevy::reflect::{std_traits::ReflectDefault, Reflect};
 use serde::{Deserialize, Serialize};
 
+use crate::core::state_machine::high_level::{StateId, TransitionId};
+
 /// Event data
-#[derive(Clone, Debug, Reflect, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Reflect, Serialize, Deserialize)]
 #[reflect(Default)]
-pub struct AnimationEvent {
-    pub id: String,
+pub enum AnimationEvent {
+    /// Trigger the most specific transition from transitioning into the provided state. That
+    /// will be:
+    /// * A direct transition, if present, or
+    /// * A global transition, if present
+    TransitionToState(StateId),
+    /// Trigger a specific transition (if possible)
+    Transition(TransitionId),
+    EndTransition,
+    StringId(String),
+}
+
+impl Default for AnimationEvent {
+    fn default() -> Self {
+        Self::StringId("".to_string())
+    }
 }
 
 /// Structure containing a sampled event and relevant metadata

--- a/crates/bevy_animation_graph/src/core/plugin.rs
+++ b/crates/bevy_animation_graph/src/core/plugin.rs
@@ -4,6 +4,7 @@ use super::pose::Pose;
 use super::prelude::GraphClip;
 use super::skeleton::loader::SkeletonLoader;
 use super::skeleton::Skeleton;
+use super::state_machine::high_level::GlobalTransition;
 use super::systems::apply_animation_to_targets;
 use super::{
     animated_scene::{
@@ -89,6 +90,7 @@ impl AnimationGraphPlugin {
             .register_type::<PatternMapperSerial>()
             .register_type::<BlendMode>()
             .register_type::<BlendSyncMode>()
+            .register_type::<GlobalTransition>()
             .register_type::<()>()
             .register_type_data::<(), ReflectDefault>()
         // --- Node registrations

--- a/crates/bevy_animation_graph/src/core/state_machine/common.rs
+++ b/crates/bevy_animation_graph/src/core/state_machine/common.rs
@@ -1,2 +1,0 @@
-pub type StateId = String;
-pub type TransitionId = String;

--- a/crates/bevy_animation_graph/src/core/state_machine/high_level/loader.rs
+++ b/crates/bevy_animation_graph/src/core/state_machine/high_level/loader.rs
@@ -1,4 +1,4 @@
-use super::{serial::StateMachineSerial, State, StateMachine, Transition};
+use super::{serial::StateMachineSerial, GlobalTransition, State, StateMachine, Transition};
 use crate::core::errors::AssetLoaderError;
 use bevy::asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext};
 
@@ -26,9 +26,15 @@ impl AssetLoader for StateMachineLoader {
         };
 
         for state_serial in serial.states {
+            let global_transition_data =
+                state_serial.global_transition.map(|gt| GlobalTransition {
+                    duration: gt.duration,
+                    graph: load_context.load(gt.graph),
+                });
             fsm.add_state(State {
                 id: state_serial.id,
                 graph: load_context.load(state_serial.graph),
+                global_transition: global_transition_data,
             });
         }
 

--- a/crates/bevy_animation_graph/src/core/state_machine/high_level/serial.rs
+++ b/crates/bevy_animation_graph/src/core/state_machine/high_level/serial.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::{animation_graph::PinMap, edge_data::DataValue};
 
-use super::{Extra, State, StateMachine, Transition};
+use super::{Extra, GlobalTransition, State, StateMachine, Transition};
 
 pub type StateIdSerial = String;
 pub type TransitionIdSerial = String;
@@ -10,6 +10,13 @@ pub type TransitionIdSerial = String;
 #[derive(Serialize, Deserialize, Clone)]
 pub struct StateSerial {
     pub id: StateIdSerial,
+    pub graph: String,
+    pub global_transition: Option<GlobalTransitionSerial>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GlobalTransitionSerial {
+    pub duration: f32,
     pub graph: String,
 }
 
@@ -49,6 +56,19 @@ impl From<&State> for StateSerial {
     fn from(value: &State) -> Self {
         Self {
             id: value.id.clone(),
+            graph: value.graph.path().unwrap().to_string(),
+            global_transition: value
+                .global_transition
+                .as_ref()
+                .map(|gt| GlobalTransitionSerial::from(gt)),
+        }
+    }
+}
+
+impl From<&GlobalTransition> for GlobalTransitionSerial {
+    fn from(value: &GlobalTransition) -> Self {
+        Self {
+            duration: value.duration.clone(),
             graph: value.graph.path().unwrap().to_string(),
         }
     }

--- a/crates/bevy_animation_graph/src/core/state_machine/high_level/serial.rs
+++ b/crates/bevy_animation_graph/src/core/state_machine/high_level/serial.rs
@@ -2,10 +2,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::{animation_graph::PinMap, edge_data::DataValue};
 
-use super::{Extra, GlobalTransition, State, StateMachine, Transition};
+use super::{Extra, GlobalTransition, State, StateId, StateMachine, Transition, TransitionId};
 
-pub type StateIdSerial = String;
-pub type TransitionIdSerial = String;
+pub type StateIdSerial = StateId;
+pub type TransitionIdSerial = TransitionId;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct StateSerial {
@@ -60,7 +60,7 @@ impl From<&State> for StateSerial {
             global_transition: value
                 .global_transition
                 .as_ref()
-                .map(|gt| GlobalTransitionSerial::from(gt)),
+                .map(GlobalTransitionSerial::from),
         }
     }
 }
@@ -68,7 +68,7 @@ impl From<&State> for StateSerial {
 impl From<&GlobalTransition> for GlobalTransitionSerial {
     fn from(value: &GlobalTransition) -> Self {
         Self {
-            duration: value.duration.clone(),
+            duration: value.duration,
             graph: value.graph.path().unwrap().to_string(),
         }
     }

--- a/crates/bevy_animation_graph/src/core/state_machine/mod.rs
+++ b/crates/bevy_animation_graph/src/core/state_machine/mod.rs
@@ -1,7 +1,2 @@
-mod core;
-
-mod common;
 pub mod high_level;
-
-pub use common::*;
-pub use core::*;
+pub mod low_level;

--- a/crates/bevy_animation_graph/src/nodes/fsm_node.rs
+++ b/crates/bevy_animation_graph/src/nodes/fsm_node.rs
@@ -4,7 +4,7 @@ use crate::core::{
     context::{PassContext, SpecContext},
     edge_data::DataSpec,
     errors::GraphError,
-    state_machine::{high_level::StateMachine, LowLevelStateMachine},
+    state_machine::{high_level::StateMachine, low_level::LowLevelStateMachine},
 };
 use bevy::prelude::*;
 

--- a/crates/bevy_animation_graph_editor/src/egui_fsm/lib.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_fsm/lib.rs
@@ -400,7 +400,11 @@ impl FsmUiContext {
             |ui| {
                 let mut title_info = None;
                 let titlebar_shape = ui.painter().add(egui::Shape::Noop);
-                let node_title = node.spec.name.clone();
+                let node_title = if node.spec.has_global_transition {
+                    format!("⚡ {}", node.spec.name.clone())
+                } else {
+                    node.spec.name.clone()
+                };
                 let response = ui.allocate_ui(ui.available_size(), |ui| ui.label(node_title));
                 let title_bar_content_rect = response.response.rect;
                 title_info.replace((titlebar_shape, title_bar_content_rect));

--- a/crates/bevy_animation_graph_editor/src/egui_fsm/node.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_fsm/node.rs
@@ -53,6 +53,7 @@ pub struct StateSpec {
     pub(crate) duration: Option<f32>,
     pub(crate) active: bool,
     pub(crate) is_start_state: bool,
+    pub(crate) has_global_transition: bool,
 }
 
 #[derive(Derivative, Clone)]

--- a/crates/bevy_animation_graph_editor/src/fsm_show.rs
+++ b/crates/bevy_animation_graph_editor/src/fsm_show.rs
@@ -205,6 +205,7 @@ impl FsmReprSpec {
                 duration: None,
                 active,
                 is_start_state: state.id == fsm.start_state,
+                has_global_transition: state.global_transition.is_some(),
                 ..Default::default()
             };
 

--- a/crates/bevy_animation_graph_editor/src/fsm_show.rs
+++ b/crates/bevy_animation_graph_editor/src/fsm_show.rs
@@ -4,8 +4,8 @@ use crate::egui_fsm::{
 };
 use bevy::{asset::Assets, math::Vec2, utils::HashMap};
 use bevy_animation_graph::core::state_machine::{
-    high_level::{State, StateMachine, Transition},
-    FSMState, StateId, TransitionId,
+    high_level::{State, StateId, StateMachine, Transition, TransitionId},
+    low_level::{FSMState, LowLevelStateId},
 };
 use bevy_inspector_egui::egui::Color32;
 
@@ -159,7 +159,7 @@ impl FsmReprSpec {
             return false;
         };
 
-        fsm_state.state == node.id
+        fsm_state.state == LowLevelStateId::HlState(node.id.clone())
     }
 
     fn transition_debug_info(

--- a/crates/bevy_animation_graph_editor/src/fsm_show.rs
+++ b/crates/bevy_animation_graph_editor/src/fsm_show.rs
@@ -174,7 +174,7 @@ impl FsmReprSpec {
         fsm.get_low_level_fsm()
             .states
             .get(&fsm_state.state)
-            .and_then(|s| s.transition.as_ref())
+            .and_then(|s| s.hl_transition.as_ref())
             .map(|t| t.hl_transition_id == transition.id)
             .unwrap_or(false)
     }

--- a/crates/bevy_animation_graph_editor/src/graph_update.rs
+++ b/crates/bevy_animation_graph_editor/src/graph_update.rs
@@ -15,10 +15,7 @@ use bevy_animation_graph::core::{
     animation_node::AnimationNode,
     context::SpecContext,
     edge_data::DataValue,
-    state_machine::{
-        high_level::{State, StateMachine, Transition},
-        StateId, TransitionId,
-    },
+    state_machine::high_level::{State, StateId, StateMachine, Transition, TransitionId},
 };
 
 use super::egui_fsm::lib::EguiFsmChange;

--- a/crates/bevy_animation_graph_editor/src/graph_update.rs
+++ b/crates/bevy_animation_graph_editor/src/graph_update.rs
@@ -306,7 +306,7 @@ pub fn convert_fsm_change(
                 .unwrap();
             GlobalChange::FsmChange {
                 asset_id: graph_id,
-                change: FsmChange::TransitionDeleted(transition_name.to_string()),
+                change: FsmChange::TransitionDeleted(transition_name.clone()),
             }
         }
         EguiFsmChange::StateRemoved(state_id) => {

--- a/crates/bevy_animation_graph_editor/src/ui.rs
+++ b/crates/bevy_animation_graph_editor/src/ui.rs
@@ -30,8 +30,9 @@ use bevy_animation_graph::core::animation_graph_player::AnimationGraphPlayer;
 use bevy_animation_graph::core::animation_node::AnimationNode;
 use bevy_animation_graph::core::context::{GraphContext, GraphContextId, SpecContext};
 use bevy_animation_graph::core::edge_data::AnimationEvent;
-use bevy_animation_graph::core::state_machine::high_level::{State, StateMachine, Transition};
-use bevy_animation_graph::core::state_machine::{StateId, TransitionId};
+use bevy_animation_graph::core::state_machine::high_level::{
+    State, StateId, StateMachine, Transition, TransitionId,
+};
 use bevy_egui::EguiContext;
 use bevy_inspector_egui::bevy_egui::EguiUserTextures;
 use bevy_inspector_egui::reflect_inspector::{Context, InspectorUi};

--- a/examples/human_fsm/examples/human_fsm.rs
+++ b/examples/human_fsm/examples/human_fsm.rs
@@ -122,14 +122,10 @@ fn keyboard_animation_control(
     }
 
     if keyboard_input.pressed(KeyCode::ArrowUp) {
-        player.send_event(AnimationEvent {
-            id: "speed_up".into(),
-        })
+        player.send_event(AnimationEvent::TransitionToState("run".into()));
     }
     if keyboard_input.pressed(KeyCode::ArrowDown) {
-        player.send_event(AnimationEvent {
-            id: "slow_down".into(),
-        })
+        player.send_event(AnimationEvent::TransitionToState("walk".into()));
     }
 
     if params.direction == Vec3::ZERO {


### PR DESCRIPTION
This PR adds:
* Global transitions, optionally enabled per FSM state
* More event modes, allowing you to request a transition to a given state (without having to know the particular transition id to trigger)

It also cleans up the state machine code, and removes most uses of "magic strings" for transition and state names when building the low-level state machine.