### PR TITLE
Enable usage of the editor as a plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "editor_as_a_plugin"
+version = "0.0.0"
+dependencies = [
+ "bevy",
+ "bevy_animation_graph",
+ "bevy_animation_graph_editor",
+ "rand",
+]
+
+[[package]]
 name = "egui"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/assets/animated_scenes/custom_node_example.animscn.ron
+++ b/assets/animated_scenes/custom_node_example.animscn.ron
@@ -1,0 +1,6 @@
+(
+    source: "models/character_rigged.glb#Scene0",
+    path_to_player: ["metarig"],
+    animation_graph: "animation_graphs/custom_node_example.animgraph.ron",
+    skeleton: "skeletons/human.skn.ron",
+)

--- a/assets/animation_graphs/custom_node_example.animgraph.ron
+++ b/assets/animation_graphs/custom_node_example.animgraph.ron
@@ -1,0 +1,42 @@
+(
+    nodes: [
+        (
+            name: "Custom node",
+            ty: "editor_as_a_plugin::MyCustomNode",
+            inner: (),
+        ),
+        (
+            name: "Human animation",
+            ty: "bevy_animation_graph::nodes::graph_node::GraphNode",
+            inner: (
+                graph: "animation_graphs/human_new.animgraph.ron",
+            ),
+        ),
+    ],
+    edges_inverted: {
+        NodeTime("Custom node", "time"): NodeTime("Human animation"),
+        OutputTime: NodeTime("Custom node"),
+        NodeData("Custom node", "pose"): NodeData("Human animation", "pose"),
+        OutputData("pose"): NodeData("Custom node", "pose"),
+    },
+    default_parameters: {},
+    input_times: {},
+    output_parameters: {
+        "pose": Pose,
+    },
+    output_time: Some(()),
+    extra: (
+        node_positions: {
+            "Custom node": (357.23087, 492.0),
+            "Human animation": (152.3077, 421.84613),
+        },
+        input_position: (-0.92308044, 500.30765),
+        output_position: (515.07697, 513.2307),
+        input_param_order: {},
+        input_time_order: {},
+        output_data_order: {
+            "pose": 0,
+        },
+        output_pose_order: {},
+    ),
+)

--- a/crates/bevy_animation_graph/src/core/pose.rs
+++ b/crates/bevy_animation_graph/src/core/pose.rs
@@ -11,10 +11,10 @@ use serde::{Deserialize, Serialize};
 /// [`Transform`]: bevy::transform::prelude::Transform
 #[derive(Asset, Reflect, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct BonePose {
-    pub(crate) rotation: Option<Quat>,
-    pub(crate) translation: Option<Vec3>,
-    pub(crate) scale: Option<Vec3>,
-    pub(crate) weights: Option<Vec<f32>>,
+    pub rotation: Option<Quat>,
+    pub translation: Option<Vec3>,
+    pub scale: Option<Vec3>,
+    pub weights: Option<Vec<f32>>,
 }
 
 impl BonePose {
@@ -69,11 +69,11 @@ impl BonePose {
 #[derive(Asset, Reflect, Clone, Debug, Default, Serialize, Deserialize)]
 #[reflect(Default)]
 pub struct Pose {
-    pub(crate) bones: Vec<BonePose>,
-    pub(crate) paths: HashMap<BoneId, usize>,
-    pub(crate) timestamp: f32,
+    pub bones: Vec<BonePose>,
+    pub paths: HashMap<BoneId, usize>,
+    pub timestamp: f32,
     #[serde(skip)]
-    pub(crate) skeleton: Handle<Skeleton>,
+    pub skeleton: Handle<Skeleton>,
 }
 
 impl Pose {

--- a/crates/bevy_animation_graph/src/lib.rs
+++ b/crates/bevy_animation_graph/src/lib.rs
@@ -191,4 +191,5 @@ pub mod prelude {
     pub use super::flipping::*;
     pub use super::interpolation::linear::*;
     pub use super::nodes::*;
+    pub use super::utils::unwrap::*;
 }

--- a/crates/bevy_animation_graph_editor/src/egui_fsm/lib.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_fsm/lib.rs
@@ -151,7 +151,7 @@ impl InteractionState {
             left_mouse_clicked && !(self.left_mouse_clicked || self.left_mouse_dragging);
 
         let alt_mouse_clicked = emulate_three_button_mouse.is_active(&io.modifiers)
-            || alt_mouse_button.map_or(false, |x| io.pointer.button_down(x));
+            || alt_mouse_button.is_some_and(|x| io.pointer.button_down(x));
 
         new_state.alt_mouse_dragging =
             (self.alt_mouse_clicked || self.alt_mouse_dragging) && alt_mouse_clicked;
@@ -882,7 +882,7 @@ impl FsmUiContext {
                     )
                 });
 
-                let should_snap = self.frame_state.hovered_pin_index.map_or(false, |idx| {
+                let should_snap = self.frame_state.hovered_pin_index.is_some_and(|idx| {
                     let start_pin = self
                         .state
                         .click_interaction_state
@@ -896,7 +896,7 @@ impl FsmUiContext {
                     .click_interaction_state
                     .link_creation
                     .end_pin_index
-                    .map_or(false, |idx| self.frame_state.hovered_pin_index != Some(idx));
+                    .is_some_and(|idx| self.frame_state.hovered_pin_index != Some(idx));
 
                 if snapping_pin_changed && self.frame_state.snap_link_idx.is_some() {
                     self.begin_link_detach(

--- a/crates/bevy_animation_graph_editor/src/egui_fsm/style.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_fsm/style.rs
@@ -166,13 +166,6 @@ impl ColorStyle {
 }
 
 /// The style used by a context
-/// Example:
-/// ``` rust
-/// # use egui_nodes::{Context, Style, ColorStyle};
-/// let mut ctx = Context::default();
-/// let style = Style { colors: ColorStyle::colors_classic(), ..Default::default() };
-/// ctx.style = style;
-/// ```
 #[derive(Debug)]
 pub struct Style {
     pub grid_spacing: f32,

--- a/crates/bevy_animation_graph_editor/src/egui_nodes/lib.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_nodes/lib.rs
@@ -151,7 +151,7 @@ impl InteractionState {
             left_mouse_clicked && !(self.left_mouse_clicked || self.left_mouse_dragging);
 
         let alt_mouse_clicked = emulate_three_button_mouse.is_active(&io.modifiers)
-            || alt_mouse_button.map_or(false, |x| io.pointer.button_down(x));
+            || alt_mouse_button.is_some_and(|x| io.pointer.button_down(x));
 
         new_state.alt_mouse_dragging =
             (self.alt_mouse_clicked || self.alt_mouse_dragging) && alt_mouse_clicked;
@@ -1080,7 +1080,7 @@ impl NodesContext {
             return false;
         }
 
-        if duplicate_link.map_or(false, |x| Some(x) != self.frame_state.snap_link_idx) {
+        if duplicate_link.is_some_and(|x| Some(x) != self.frame_state.snap_link_idx) {
             return false;
         }
         true
@@ -1218,7 +1218,7 @@ impl NodesContext {
                     )
                 });
 
-                let should_snap = self.frame_state.hovered_pin_index.map_or(false, |idx| {
+                let should_snap = self.frame_state.hovered_pin_index.is_some_and(|idx| {
                     let start_pin = &self.pins[&self
                         .state
                         .click_interaction_state
@@ -1232,7 +1232,7 @@ impl NodesContext {
                     .click_interaction_state
                     .link_creation
                     .end_pin_index
-                    .map_or(false, |idx| self.frame_state.hovered_pin_index != Some(idx));
+                    .is_some_and(|idx| self.frame_state.hovered_pin_index != Some(idx));
 
                 if snapping_pin_changed && self.frame_state.snap_link_idx.is_some() {
                     self.begin_link_detach(
@@ -1271,12 +1271,10 @@ impl NodesContext {
                     self.settings.style.colors[ColorStyle::Link as usize],
                 )));
 
-                let link_creation_on_snap =
-                    self.frame_state.hovered_pin_index.map_or(false, |idx| {
-                        (self.pins[&idx].spec.flags
-                            & AttributeFlags::EnableLinkCreationOnSnap as usize)
-                            != 0
-                    });
+                let link_creation_on_snap = self.frame_state.hovered_pin_index.is_some_and(|idx| {
+                    (self.pins[&idx].spec.flags & AttributeFlags::EnableLinkCreationOnSnap as usize)
+                        != 0
+                });
 
                 if !should_snap {
                     self.state

--- a/crates/bevy_animation_graph_editor/src/egui_nodes/style.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_nodes/style.rs
@@ -158,13 +158,6 @@ impl ColorStyle {
 }
 
 /// The style used by a context
-/// Example:
-/// ``` rust
-/// # use egui_nodes::{Context, Style, ColorStyle};
-/// let mut ctx = Context::default();
-/// let style = Style { colors: ColorStyle::colors_classic(), ..Default::default() };
-/// ctx.style = style;
-/// ```
 #[derive(Debug)]
 pub struct Style {
     pub grid_spacing: f32,

--- a/crates/bevy_animation_graph_editor/src/lib.rs
+++ b/crates/bevy_animation_graph_editor/src/lib.rs
@@ -1,0 +1,73 @@
+mod asset_saving;
+mod egui_fsm;
+mod egui_inspector_impls;
+mod egui_nodes;
+mod fsm_show;
+mod graph_show;
+mod graph_update;
+mod scanner;
+mod tree;
+mod ui;
+
+use asset_saving::AssetSavingPlugin;
+use bevy::prelude::*;
+use bevy_animation_graph::core::plugin::AnimationGraphPlugin;
+use bevy_egui::EguiPlugin;
+use bevy_inspector_egui::{bevy_egui, DefaultInspectorConfigPlugin};
+use clap::Parser;
+use egui_inspector_impls::BetterInspectorPlugin;
+use scanner::ScannerPlugin;
+use std::path::PathBuf;
+use ui::{graph_debug_draw_bone_system, UiState};
+
+#[derive(Parser, Resource)]
+struct Cli {
+    #[arg(short, long)]
+    asset_source: PathBuf,
+}
+
+/// Will start up an animation graph asset editor. This plugin will add all other required
+/// plugins: if you use it, do not add [`DefaultPlugins`], [`EguiPlugin`] or others manually (see
+/// plugin source code for full up-to-date list).
+///
+/// This plugin also takes care of command-line parsing.
+///
+/// You only need to add plugins necessary to register your custom animation node types, if you
+/// have any.
+pub struct AnimationGraphEditorPlugin;
+
+impl Plugin for AnimationGraphEditorPlugin {
+    fn build(&self, app: &mut App) {
+        let cli = Cli::parse();
+
+        app //
+            .add_plugins(
+                DefaultPlugins.set(AssetPlugin {
+                    file_path: std::fs::canonicalize(&cli.asset_source)
+                        .unwrap()
+                        .to_string_lossy()
+                        .into(),
+                    ..Default::default()
+                }),
+            )
+            .add_plugins(EguiPlugin)
+            .add_plugins(AnimationGraphPlugin)
+            .add_plugins(DefaultInspectorConfigPlugin)
+            .add_plugins(BetterInspectorPlugin)
+            .add_plugins(AssetSavingPlugin)
+            .add_plugins(ScannerPlugin)
+            .insert_resource(UiState::new())
+            .insert_resource(cli)
+            .add_systems(Startup, ui::setup_system)
+            .add_systems(
+                Update,
+                (
+                    ui::show_ui_system,
+                    ui::asset_save_event_system,
+                    ui::scene_spawner_system,
+                    graph_debug_draw_bone_system,
+                )
+                    .chain(),
+            );
+    }
+}

--- a/crates/bevy_animation_graph_editor/src/main.rs
+++ b/crates/bevy_animation_graph_editor/src/main.rs
@@ -1,65 +1,10 @@
-mod asset_saving;
-mod egui_fsm;
-mod egui_inspector_impls;
-mod egui_nodes;
-mod fsm_show;
-mod graph_show;
-mod graph_update;
-mod scanner;
-mod tree;
-mod ui;
-
-use asset_saving::AssetSavingPlugin;
 use bevy::prelude::*;
-use bevy_animation_graph::core::plugin::AnimationGraphPlugin;
-use bevy_egui::EguiPlugin;
-use bevy_inspector_egui::{bevy_egui, DefaultInspectorConfigPlugin};
-use clap::Parser;
-use egui_inspector_impls::BetterInspectorPlugin;
-use scanner::ScannerPlugin;
-use std::path::PathBuf;
-use ui::{graph_debug_draw_bone_system, UiState};
-
-#[derive(Parser, Resource)]
-struct Cli {
-    #[arg(short, long)]
-    asset_source: PathBuf,
-}
+use bevy_animation_graph_editor::AnimationGraphEditorPlugin;
 
 fn main() {
-    let cli = Cli::parse();
-
     let mut app = App::new();
 
-    app //
-        .add_plugins(
-            DefaultPlugins.set(AssetPlugin {
-                file_path: std::fs::canonicalize(&cli.asset_source)
-                    .unwrap()
-                    .to_string_lossy()
-                    .into(),
-                ..Default::default()
-            }),
-        )
-        .add_plugins(EguiPlugin)
-        .add_plugins(AnimationGraphPlugin)
-        .add_plugins(DefaultInspectorConfigPlugin)
-        .add_plugins(BetterInspectorPlugin)
-        .add_plugins(AssetSavingPlugin)
-        .add_plugins(ScannerPlugin)
-        .insert_resource(UiState::new())
-        .insert_resource(cli)
-        .add_systems(Startup, ui::setup_system)
-        .add_systems(
-            Update,
-            (
-                ui::show_ui_system,
-                ui::asset_save_event_system,
-                ui::scene_spawner_system,
-                graph_debug_draw_bone_system,
-            )
-                .chain(),
-        );
+    app.add_plugins(AnimationGraphEditorPlugin);
 
     app.run();
 }

--- a/examples/editor_as_a_plugin/Cargo.toml
+++ b/examples/editor_as_a_plugin/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "editor_as_a_plugin"
+publish = false
+edition = { workspace = true }
+
+[dependencies]
+bevy = { workspace = true }
+bevy_animation_graph = { path = "../../crates/bevy_animation_graph" }
+bevy_animation_graph_editor = { path = "../../crates/bevy_animation_graph_editor" }
+rand = "0.8"

--- a/examples/editor_as_a_plugin/README.md
+++ b/examples/editor_as_a_plugin/README.md
@@ -1,0 +1,14 @@
+This example shows how to create your own editor binary using the provided
+`AnimationGraphEditorPlugin`.
+
+While the `bevy_animation_graph_editor` crate already bundles an editor binary, there
+are cases where it may be preferable to create your own binary that uses the
+editor as a plugin. For example:
+* Your crate defines custom `AnimationNode`s, which you would like to register
+  so that they are available in the editor.
+* Your crate depends on a git version or fork of the animation graph workspace, and
+  you would like to use that particular version of the editor without having to
+  install it globally.
+
+For demonstration purposes, we define a custom animation node in this crate,
+which will appear in the editor.

--- a/examples/editor_as_a_plugin/examples/editor_as_a_plugin.rs
+++ b/examples/editor_as_a_plugin/examples/editor_as_a_plugin.rs
@@ -1,0 +1,99 @@
+extern crate bevy;
+extern crate bevy_animation_graph;
+
+use bevy::prelude::*;
+use bevy_animation_graph::{
+    core::{animation_graph::PinMap, errors::GraphError, pose::Pose},
+    prelude::{DataSpec, NodeLike, PassContext, ReflectNodeLike, SpecContext, UnwrapVal},
+};
+use bevy_animation_graph_editor::AnimationGraphEditorPlugin;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(AnimationGraphEditorPlugin);
+    app.register_type::<MyCustomNode>();
+    app.run();
+}
+
+/// Custom node that doesn't do anything productive, it randomizes the position of each joint
+/// slightly
+#[derive(Reflect, Clone, Debug, Default)]
+#[reflect(Default, NodeLike)]
+pub struct MyCustomNode;
+
+impl MyCustomNode {
+    pub const IN_POSE: &'static str = "pose";
+    pub const IN_TIME: &'static str = "time";
+    pub const OUT_POSE: &'static str = "pose";
+}
+
+impl NodeLike for MyCustomNode {
+    fn duration(&self, mut ctx: PassContext) -> Result<(), GraphError> {
+        // Nodes need to "announce" their duration. Here, we just read the duration for our
+        // dependency node and forward that, since this node does not change the length of the
+        // clip. This won't always be the case; for example a node that applies a playback speed multiplier
+        // to an animation will need to adjust the announced duration accordingly.
+        let back_duration = ctx.duration_back(Self::IN_TIME)?;
+        ctx.set_duration_fwd(back_duration);
+        Ok(())
+    }
+
+    fn update(&self, mut ctx: PassContext) -> Result<(), GraphError> {
+        // Get time incoming time delta (or absolute time signal).
+        let input = ctx.time_update_fwd()?;
+        // Forward the time signal to dependency nodes
+        ctx.set_time_update_back(Self::IN_TIME, input);
+        // Now that we made the time signal available to dependency nodes, we can read their output
+        // data. Nodes are evaluated lazily, so they won't compute anything until we attempt to
+        // read them.
+        let mut in_pose: Pose = ctx.data_back(Self::IN_POSE)?.val();
+
+        // This node doesn't do anything "useful", but for demonstration purposes let's add some
+        // random noise to the translation of each bone that has an animated translation.
+        for bone in &mut in_pose.bones {
+            if let Some(pos) = &mut bone.translation {
+                let offset = Vec3::new(
+                    rand::random::<f32>() - 0.5,
+                    rand::random::<f32>() - 0.5,
+                    rand::random::<f32>() - 0.5,
+                ) * 0.035;
+
+                *pos += offset;
+            }
+        }
+
+        // Set the "current time" for this node.
+        ctx.set_time(in_pose.timestamp);
+
+        // Publish the output pose to the corresponding output data pin
+        ctx.set_data_fwd(Self::OUT_POSE, in_pose);
+
+        Ok(())
+    }
+
+    fn time_input_spec(&self, _: SpecContext) -> PinMap<()> {
+        // Specify input time pins
+        [(Self::IN_TIME.into(), ())].into()
+    }
+
+    fn time_output_spec(&self, _ctx: SpecContext) -> Option<()> {
+        // Specify that this node has an output time pin. Nodes can only have one or zero output
+        // time pins
+        Some(())
+    }
+
+    fn data_input_spec(&self, _: SpecContext) -> PinMap<DataSpec> {
+        // Specify input data pins for this node
+        [(Self::IN_POSE.into(), DataSpec::Pose)].into()
+    }
+
+    fn data_output_spec(&self, _: SpecContext) -> PinMap<DataSpec> {
+        // Specify output data pins for this node
+        [(Self::OUT_POSE.into(), DataSpec::Pose)].into()
+    }
+
+    fn display_name(&self) -> String {
+        // This is the name that will be displayed in the editor for the node
+        "Custom example node".into()
+    }
+}


### PR DESCRIPTION
It's time to start reaping the benefits of the dynamic registration of animation nodes. This PR:
* Makes the animation graph editor available as a plugin `AnimationGraphEditorPlugin`, so that users can make their own editor binaries with their custom nodes pre-registered.
* Adds an `editor_as_a_plugin` example that shows how to do just that, defining and registering a custom animation node so that it is usable in the editor.