### PR TITLE
Retargeting: allow overriding specific path components in animation targets

### DIFF
--- a/assets/animated_scenes/human_retargeting.animscn.ron
+++ b/assets/animated_scenes/human_retargeting.animscn.ron
@@ -1,0 +1,7 @@
+(
+    source: "models/character_rigged.glb#Scene0",
+    path_to_player: ["metarig"],
+    animation_graph: "animation_graphs/human_new.animgraph.ron",
+    bone_path_overrides: { "shin.L": "nothing matches" },
+    skeleton: "skeletons/human.skn.ron",
+)

--- a/crates/bevy_animation_graph/src/core/animated_scene/loader.rs
+++ b/crates/bevy_animation_graph/src/core/animated_scene/loader.rs
@@ -17,6 +17,7 @@ struct AnimatedSceneSerial {
     source: String,
     animation_graph: String,
     skeleton: String,
+    #[serde(default)]
     bone_path_overrides: HashMap<String, String>,
 }
 

--- a/crates/bevy_animation_graph/src/core/animated_scene/loader.rs
+++ b/crates/bevy_animation_graph/src/core/animated_scene/loader.rs
@@ -1,6 +1,7 @@
 use bevy::{
     asset::{io::Reader, AssetLoader, Handle, LoadContext},
     scene::Scene,
+    utils::HashMap,
 };
 use serde::{Deserialize, Serialize};
 
@@ -14,9 +15,9 @@ use super::AnimatedScene;
 #[derive(Serialize, Deserialize, Clone)]
 struct AnimatedSceneSerial {
     source: String,
-    path_to_player: Vec<String>,
     animation_graph: String,
     skeleton: String,
+    bone_path_overrides: HashMap<String, String>,
 }
 
 #[derive(Default)]
@@ -44,9 +45,9 @@ impl AssetLoader for AnimatedSceneLoader {
         Ok(AnimatedScene {
             source,
             processed_scene: None,
-            path_to_player: serial.path_to_player,
             animation_graph,
             skeleton,
+            bone_path_overrides: serial.bone_path_overrides,
         })
     }
 


### PR DESCRIPTION
Currently, in order to apply animations across models we require all bone paths to be the identical. This PR exposes some configuration to override certain components of bone paths at the scene level.

To make use of it, add a `bone_path_overrides` field to your animated scene asset:
```ron
(
    source: "models/character_rigged.glb#Scene0",
    path_to_player: ["metarig"],
    animation_graph: "animation_graphs/human_new.animgraph.ron",
    bone_path_overrides: { "player_model_a": "player_model_b" },
    skeleton: "skeletons/human.skn.ron",
)
```
This will replace all path components equal to `player_model_a` with `player_model_b` all bone paths in your scene, so animations using `player_model_b` in bone paths will be playable.