### PR TITLE
fix: order assets alphabetically and fix bug with scene controls

### DIFF
--- a/crates/bevy_animation_graph_editor/src/ui/actions/graph.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/actions/graph.rs
@@ -22,7 +22,7 @@ use crate::{
     ui::egui_inspector_impls::OrderedMap,
 };
 
-use super::saving::DirtyAssets;
+use super::{run_handler, saving::DirtyAssets, DynamicAction};
 
 pub enum GraphAction {
     CreateLink(CreateLink),
@@ -392,5 +392,24 @@ impl GraphAndContext<'_> {
         if let Some(indices) = indices {
             self.graph_indices_map.indices.insert(graph_id, indices);
         }
+    }
+}
+
+pub struct CreateGraphAction;
+
+impl DynamicAction for CreateGraphAction {
+    fn handle(self: Box<Self>, world: &mut World) {
+        run_handler(world, "Could not create clip preview")(
+            |In(_),
+             mut graph_assets: ResMut<Assets<AnimationGraph>>,
+             mut dirty_assets: ResMut<DirtyAssets>| {
+                let new_handle = graph_assets.add(AnimationGraph::default());
+                info!("Creating graph with id: {:?}", new_handle.id());
+                dirty_assets
+                    .assets
+                    .insert(new_handle.id().untyped(), new_handle.untyped());
+            },
+            *self,
+        )
     }
 }

--- a/crates/bevy_animation_graph_editor/src/ui/core.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/core.rs
@@ -132,6 +132,7 @@ impl ViewState {
 
         DockArea::new(&mut self.dock_state)
             .style(Style::from_egui(ctx.style().as_ref()))
+            .id(egui::Id::new(self.name.clone()))
             .show(ctx, &mut tab_viewer);
     }
 
@@ -319,7 +320,9 @@ impl egui_dock::TabViewer for TabViewer<'_> {
                             windows,
                         };
 
-                        window.ui(ui, self.world, &mut ctx);
+                        ui.push_id(ui.id().with(*editor_window), |ui| {
+                            window.ui(ui, self.world, &mut ctx);
+                        })
                     });
             }
         }

--- a/crates/bevy_animation_graph_editor/src/ui/editor_windows/fsm_selector.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/editor_windows/fsm_selector.rs
@@ -1,17 +1,12 @@
-use bevy::{
-    asset::{AssetServer, Assets, Handle},
-    ecs::world::CommandQueue,
-    prelude::World,
-};
+use bevy::{ecs::world::CommandQueue, prelude::World};
 use bevy_animation_graph::core::state_machine::high_level::{State, StateMachine, Transition};
 use egui_dock::egui;
 
 use crate::{
     egui_fsm::lib::FsmUiContext,
-    tree::TreeResult,
     ui::{
         core::{EditorWindowContext, EditorWindowExtension, FsmSelection, InspectorSelection},
-        utils,
+        utils::tree_asset_selector,
     },
 };
 
@@ -21,25 +16,8 @@ pub struct FsmSelectorWindow;
 impl EditorWindowExtension for FsmSelectorWindow {
     fn ui(&mut self, ui: &mut egui::Ui, world: &mut World, ctx: &mut EditorWindowContext) {
         let mut queue = CommandQueue::default();
-        let mut chosen_handle: Option<Handle<StateMachine>> = None;
+        let chosen_handle = tree_asset_selector::<StateMachine>(ui, world);
 
-        world.resource_scope::<AssetServer, ()>(|world, asset_server| {
-            world.resource_scope::<Assets<StateMachine>, ()>(|_world, mut graph_assets| {
-                let mut assets: Vec<_> = graph_assets.ids().collect();
-                assets.sort();
-                let paths = assets
-                    .into_iter()
-                    .map(|id| (utils::handle_path(id.untyped(), &asset_server), id))
-                    .collect();
-                if let TreeResult::Leaf(id) = utils::path_selector(ui, paths) {
-                    chosen_handle = Some(graph_assets.get_strong_handle(id).unwrap());
-                }
-                // ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
-                //     let mut graph_handles = world.get_resource_mut::<GraphHandles>().unwrap();
-                //     CREATE NEW FSM & STUFF
-                // });
-            });
-        });
         queue.apply(world);
         if let Some(chosen_id) = chosen_handle {
             ctx.global_state.fsm_editor = Some(FsmSelection {

--- a/crates/bevy_animation_graph_editor/src/ui/editor_windows/scene_preview.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/editor_windows/scene_preview.rs
@@ -16,7 +16,7 @@ use egui_dock::egui;
 use crate::ui::{
     core::EditorWindowExtension,
     utils::{orbit_camera_scene_show, orbit_camera_transform, orbit_camera_update, OrbitView},
-    PreviewScene, SubSceneConfig, SubSceneSyncAction,
+    PartOfSubScene, PreviewScene, SubSceneConfig, SubSceneSyncAction,
 };
 
 #[derive(Debug, Default)]
@@ -40,8 +40,12 @@ impl EditorWindowExtension for ScenePreviewWindow {
             view: self.orbit_view.clone(),
         };
 
-        let mut query = world.query::<(&AnimatedSceneInstance, &PreviewScene)>();
-        if let Ok((instance, _)) = query.get_single(world) {
+        let ui_texture_id = ui.id().with("Scene preview texture");
+        let mut query = world.query::<(&AnimatedSceneInstance, &PreviewScene, &PartOfSubScene)>();
+        if let Some((instance, _, _)) = query
+            .iter(world)
+            .find(|(_, _, PartOfSubScene(uid))| *uid == ui_texture_id)
+        {
             // Scene playback control will only be shown once the scene is created
             // (so from the second frame onwards)
             let entity = instance.player_entity();
@@ -69,7 +73,7 @@ impl EditorWindowExtension for ScenePreviewWindow {
             });
         }
 
-        orbit_camera_scene_show(&config, &mut self.orbit_view, ui, world, ui.id());
+        orbit_camera_scene_show(&config, &mut self.orbit_view, ui, world, ui_texture_id);
     }
 
     fn display_name(&self) -> String {

--- a/crates/bevy_animation_graph_editor/src/ui/editor_windows/scene_selector.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/editor_windows/scene_selector.rs
@@ -1,18 +1,10 @@
-use bevy::{
-    asset::{AssetServer, Assets, Handle},
-    ecs::world::CommandQueue,
-    prelude::World,
-    utils::HashMap,
-};
+use bevy::{prelude::World, utils::HashMap};
 use bevy_animation_graph::{core::edge_data::AnimationEvent, prelude::AnimatedScene};
 use egui_dock::egui;
 
-use crate::{
-    tree::TreeResult,
-    ui::{
-        core::{EditorWindowContext, EditorWindowExtension, SceneSelection},
-        utils,
-    },
+use crate::ui::{
+    core::{EditorWindowContext, EditorWindowExtension, SceneSelection},
+    utils::tree_asset_selector,
 };
 
 #[derive(Debug)]
@@ -20,34 +12,10 @@ pub struct SceneSelectorWindow;
 
 impl EditorWindowExtension for SceneSelectorWindow {
     fn ui(&mut self, ui: &mut egui::Ui, world: &mut World, ctx: &mut EditorWindowContext) {
-        let mut queue = CommandQueue::default();
-
-        let mut chosen_handle: Option<Handle<AnimatedScene>> = None;
-
-        world.resource_scope::<AssetServer, ()>(|world, asset_server| {
-            // create a context with access to the world except for the `R` resource
-            world.resource_scope::<Assets<AnimatedScene>, ()>(|_, assets| {
-                let mut assets: Vec<_> = assets.ids().collect();
-                assets.sort();
-                let paths = assets
-                    .into_iter()
-                    .map(|id| (utils::handle_path(id.untyped(), &asset_server), id))
-                    .collect();
-                let chosen_id = utils::path_selector(ui, paths);
-                if let TreeResult::Leaf(id) = chosen_id {
-                    chosen_handle = Some(
-                        asset_server
-                            .get_handle(asset_server.get_path(id).unwrap())
-                            .unwrap(),
-                    )
-                }
-            });
-        });
-        queue.apply(world);
+        let chosen_handle = tree_asset_selector::<AnimatedScene>(ui, world);
 
         // TODO: Make sure to clear out all places that hold a graph context id
         //       when changing scene selection.
-
         if let Some(chosen_handle) = chosen_handle {
             let event_table = if let Some(scn) = &ctx.global_state.scene {
                 scn.event_table.clone()

--- a/crates/bevy_animation_graph_editor/src/ui/reflect_widgets/asset_picker.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/reflect_widgets/asset_picker.rs
@@ -7,6 +7,8 @@ use bevy::asset::{Asset, AssetServer, Assets, Handle};
 use bevy_inspector_egui::reflect_inspector::InspectorUi;
 use egui_dock::egui;
 
+use crate::ui::utils::asset_sort_key;
+
 use super::{EguiInspectorExtension, MakeBuffer};
 
 pub struct AssetPickerInspector<T> {
@@ -58,7 +60,7 @@ impl<T: Asset> EguiInspectorExtension for AssetPickerInspector<T> {
             })
             .show_ui(ui, |ui| {
                 let mut assets_ids: Vec<_> = t_assets.ids().collect();
-                assets_ids.sort();
+                assets_ids.sort_by_key(|id| asset_sort_key(*id, &asset_server));
                 for asset_id in assets_ids {
                     ui.selectable_value(
                         &mut selected,
@@ -91,6 +93,8 @@ impl<T: Asset> EguiInspectorExtension for AssetPickerInspector<T> {
         env.ui_for_reflect_readonly_with_options(buffer, ui, id, &());
     }
 }
+
+impl<T: Asset> AssetPickerInspector<T> {}
 
 impl<T: Asset> MakeBuffer<()> for Handle<T> {
     fn make_buffer(&self) {}


### PR DESCRIPTION
Just doing a bit of polish and bugfixing. Changes in this PR:
* Asset pickers (both dropdown and tree-style) now show assets ordered lexicographically.
* Fix bug where scene preview playback controls would not show when more than one texture views are open at once.