### PR TITLE
reasonable column sizing in inspector

### DIFF
--- a/crates/bevy_animation_graph_core/src/utils/mod.rs
+++ b/crates/bevy_animation_graph_core/src/utils/mod.rs
@@ -1,3 +1,21 @@
 pub mod delaunay;
 pub mod geometry;
 pub mod loading;
+
+use bevy::asset::AssetPath;
+use std::path::PathBuf;
+
+/// Normalize an [`AssetPath`] to use forward slashes, ensuring portability across platforms.
+///
+/// On Windows, `std::path::Path` uses backslashes as separators. This function converts them to
+/// forward slashes so that serialized asset paths can be loaded on any platform.
+pub fn normalize_asset_path(path: AssetPath<'static>) -> AssetPath<'static> {
+    let normalized = AssetPath::from_path_buf(PathBuf::from(
+        path.path().to_string_lossy().replace('\\', "/"),
+    ));
+    match path.label() {
+        Some(label) => normalized.with_label(label.to_string()).into_owned(),
+        None => normalized.into_owned(),
+    }
+}
+

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/data_value.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/data_value.rs
@@ -81,9 +81,13 @@ impl<'a> egui::Widget for DataValueWidget<'a> {
                     response |= ui.add(EntityPathWidget::new_salted(entity_path, "entity path"));
                 }
                 DataValue::BoneMask(bone_mask) => {
-                    response |= PopupWidget::new_salted("bone mask popup").ui(ui, |ui| {
-                        ui.add(BoneMaskWidget::new(bone_mask).with_skeleton(self.skeleton))
-                    });
+                    response |= PopupWidget::new_salted("bone mask popup")
+                        .with_max_width(500.)
+                        .ui(ui, |ui| {
+                            ui.add(
+                                BoneMaskWidget::new(bone_mask).with_skeleton(self.skeleton),
+                            )
+                        });
                 }
                 DataValue::Pose(_) => {
                     response |= ui.label("Pose value editing not supported");

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/data_value.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/data_value.rs
@@ -60,6 +60,9 @@ impl<'a> egui::Widget for DataValueWidget<'a> {
 
             match self.data_value {
                 DataValue::F32(val) => {
+                    if !val.is_finite() {
+                        *val = 0.0;
+                    }
                     response |= ui.add(egui::DragValue::new(val));
                 }
                 DataValue::Bool(val) => {

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/entity_path.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/entity_path.rs
@@ -47,7 +47,8 @@ impl<'a> egui::Widget for EntityPathWidget<'a> {
             });
 
             let response = ui.add(
-                egui::TextEdit::singleline(&mut buffer.value).min_size(egui::Vec2::new(350., 0.)),
+                egui::TextEdit::singleline(&mut buffer.value)
+                    .desired_width(ui.available_width()),
             );
 
             let top_k = self

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/graph_input_pin.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/graph_input_pin.rs
@@ -48,7 +48,9 @@ impl<'a> egui::Widget for GraphInputPinWidget<'a> {
                 GraphInputPin::Passthrough(pin_id)
                 | GraphInputPin::FromFsmSource(pin_id)
                 | GraphInputPin::FromFsmTarget(pin_id) => {
-                    response |= ui.add(egui::TextEdit::singleline(pin_id).desired_width(100.));
+                    response |= ui.add(
+                        egui::TextEdit::singleline(pin_id).desired_width(ui.available_width()),
+                    );
                 }
                 GraphInputPin::FsmBuiltin(fsm_builtin_pin) => {
                     let original = fsm_builtin_pin.clone();

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/hash_like.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/hash_like.rs
@@ -1,5 +1,33 @@
 use std::{hash::Hash, marker::PhantomData};
 
+/// Creates a child Ui with a fixed width that won't overflow into the parent's
+/// horizontal layout, even if the child content is wider than `col_width`.
+fn fixed_width_column(
+    ui: &mut egui::Ui,
+    id: egui::Id,
+    col_width: f32,
+    add_contents: impl FnOnce(&mut egui::Ui) -> egui::Response,
+) -> egui::Response {
+    let col_rect = egui::Rect::from_min_size(
+        ui.cursor().min,
+        egui::vec2(col_width, ui.max_rect().bottom() - ui.cursor().min.y),
+    );
+    let mut child_ui = ui.new_child(
+        egui::UiBuilder::new()
+            .id_salt(id)
+            .max_rect(col_rect)
+            .layout(*ui.layout()),
+    );
+    let response = add_contents(&mut child_ui);
+    let used_height = child_ui.min_rect().height();
+    // Advance parent cursor by exactly col_width, regardless of child overflow
+    ui.advance_cursor_after_rect(egui::Rect::from_min_size(
+        col_rect.min,
+        egui::vec2(col_width, used_height),
+    ));
+    response
+}
+
 pub struct HashLikeWidget<'a, K, V, C, H> {
     pub map: &'a mut H,
     pub id_hash: egui::Id,
@@ -44,8 +72,8 @@ where
             let mut pending_delete_key_idx = None;
             let mut pending_add_key = None;
 
-            egui::Grid::new(self.id_hash.with("hashmap grid")).show(ui, |ui| {
-                for (idx, key) in buffer.ordering.iter_mut().enumerate() {
+            for (idx, key) in buffer.ordering.iter_mut().enumerate() {
+                ui.horizontal(|ui| {
                     ui.push_id(egui::Id::new(idx).with("delete button"), |ui| {
                         let button_response = ui.button("x");
                         if button_response.clicked() {
@@ -56,23 +84,28 @@ where
                         response |= button_response;
                     });
 
-                    ui.push_id(egui::Id::new(idx).with("edit existing key"), |ui| {
-                        response |= self.map.edit_existing_key(ui, key);
-                    });
+                    let spacing = ui.spacing().item_spacing.x;
+                    let col_width = (ui.available_width() - spacing).max(0.) / 2.0;
 
-                    ui.push_id(egui::Id::new(idx).with("edit existing value"), |ui| {
-                        response |= self.map.edit_existing_value_for(ui, key);
-                    });
+                    response |= fixed_width_column(
+                        ui,
+                        egui::Id::new(idx).with("edit existing key"),
+                        col_width,
+                        |ui| self.map.edit_existing_key(ui, key),
+                    );
+                    response |= fixed_width_column(
+                        ui,
+                        egui::Id::new(idx).with("edit existing value"),
+                        col_width,
+                        |ui| self.map.edit_existing_value_for(ui, key),
+                    );
+                });
+            }
 
-                    ui.end_row();
-                }
+            ui.separator();
 
-                ui.separator();
-                ui.separator();
-                ui.separator();
-                ui.end_row();
-
-                ui.push_id(egui::Id::new(-1).with("create button"), |ui| {
+            ui.horizontal(|ui| {
+                ui.push_id(egui::Id::new(-1i32).with("create button"), |ui| {
                     let button_response = ui.button("+");
                     if button_response.clicked() {
                         pending_add_key = Some(key.clone());
@@ -83,13 +116,21 @@ where
                     response |= button_response;
                 });
 
-                ui.push_id(egui::Id::new(-1).with("edit new key"), |ui| {
-                    response |= self.map.edit_new_key(ui, key, context);
-                });
+                let spacing = ui.spacing().item_spacing.x;
+                let col_width = (ui.available_width() - spacing).max(0.) / 2.0;
 
-                ui.push_id(egui::Id::new(-1).with("edit new value"), |ui| {
-                    response |= self.map.edit_new_value(ui, value, context);
-                });
+                response |= fixed_width_column(
+                    ui,
+                    egui::Id::new(-1i32).with("edit new key"),
+                    col_width,
+                    |ui| self.map.edit_new_key(ui, key, context),
+                );
+                response |= fixed_width_column(
+                    ui,
+                    egui::Id::new(-1i32).with("edit new value"),
+                    col_width,
+                    |ui| self.map.edit_new_value(ui, value, context),
+                );
             });
 
             if let Some(delete_idx) = pending_delete_key_idx {

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/io_spec.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/io_spec.rs
@@ -193,9 +193,18 @@ impl<'a, I: Clone + std::fmt::Debug + Eq + std::hash::Hash + Default + Send + Sy
         input: &mut I,
         spec: &mut DataSpec,
     ) -> egui::Response {
-        let mut response = show_i(ui, input);
-        response |= ui.add(DataSpecWidget::new_salted(spec, "data spec widget"));
-
+        let mut response = ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover());
+        egui_extras::StripBuilder::new(ui)
+            .size(egui_extras::Size::remainder())
+            .size(egui_extras::Size::initial(80.))
+            .horizontal(|mut strip| {
+                strip.cell(|ui| {
+                    response |= show_i(ui, input);
+                });
+                strip.cell(|ui| {
+                    response |= ui.add(DataSpecWidget::new_salted(spec, "data spec widget"));
+                });
+            });
         response
     }
 
@@ -296,9 +305,19 @@ impl<'a, I: Clone + std::fmt::Debug + Eq + std::hash::Hash + Default + Send + Sy
         input: &mut PinId,
         spec: &mut DataSpec,
     ) -> egui::Response {
-        let mut response = ui.add(egui::TextEdit::singleline(input).desired_width(100.));
-        response |= ui.add(DataSpecWidget::new_salted(spec, "data spec widget"));
-
+        let mut response = ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover());
+        egui_extras::StripBuilder::new(ui)
+            .size(egui_extras::Size::remainder())
+            .size(egui_extras::Size::initial(80.))
+            .horizontal(|mut strip| {
+                strip.cell(|ui| {
+                    response |=
+                        ui.add(egui::TextEdit::singleline(input).desired_width(f32::INFINITY));
+                });
+                strip.cell(|ui| {
+                    response |= ui.add(DataSpecWidget::new_salted(spec, "data spec widget"));
+                });
+            });
         response
     }
 

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/popup.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/popup.rs
@@ -3,6 +3,7 @@ use egui::containers::menu::MenuConfig;
 pub struct PopupWidget {
     pub id_hash: egui::Id,
     pub button_label: String,
+    pub max_width: Option<f32>,
 }
 
 impl PopupWidget {
@@ -10,7 +11,13 @@ impl PopupWidget {
         Self {
             id_hash: egui::Id::new(salt),
             button_label: "edit".into(),
+            max_width: None,
         }
+    }
+
+    pub fn with_max_width(mut self, max_width: f32) -> Self {
+        self.max_width = Some(max_width);
+        self
     }
 
     pub fn ui(
@@ -18,6 +25,13 @@ impl PopupWidget {
         ui: &mut egui::Ui,
         inner: impl FnOnce(&mut egui::Ui) -> egui::Response,
     ) -> egui::Response {
+        let max_width = self.max_width;
+        let wrapped_inner = move |ui: &mut egui::Ui| -> egui::Response {
+            if let Some(w) = max_width {
+                ui.set_max_width(w);
+            }
+            inner(ui)
+        };
         ui.push_id(self.id_hash, |ui| {
             ui.horizontal(|ui| {
                 let config =
@@ -25,11 +39,11 @@ impl PopupWidget {
                 let (mut button_response, inner) = if egui::containers::menu::is_in_menu(ui) {
                     egui::containers::menu::SubMenuButton::new(&self.button_label)
                         .config(config)
-                        .ui(ui, inner)
+                        .ui(ui, wrapped_inner)
                 } else {
                     egui::containers::menu::MenuButton::new(&self.button_label)
                         .config(config)
-                        .ui(ui, inner)
+                        .ui(ui, wrapped_inner)
                 };
 
                 if inner.is_some_and(|i| i.inner.changed()) {

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/ragdoll_config.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/ragdoll_config.rs
@@ -43,6 +43,7 @@ impl<'a> egui::Widget for RagdollConfigWidget<'a> {
             let mut response = ui.button("Edit");
             let popup_response = egui::Popup::from_toggle_button_response(&response)
                 .close_behavior(egui::PopupCloseBehavior::IgnoreClicks)
+                .width(500.)
                 .show(|ui| {
                     let mut response = ui.heading("Defaults");
                     ui.horizontal(|ui| {

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/uuid.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/uuid.rs
@@ -46,7 +46,8 @@ impl<'a> egui::Widget for UuidWidget<'a> {
             });
 
             let mut response = ui.add(
-                egui::TextEdit::singleline(&mut data.buffer).min_size(egui::Vec2::new(250., 0.)),
+                egui::TextEdit::singleline(&mut data.buffer)
+                    .desired_width(ui.available_width()),
             );
 
             // Mark non-changed; we only consider the response changed if the uuid string is valid

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/vec2.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/vec2.rs
@@ -33,8 +33,8 @@ impl<'a> Vec2Widget<'a> {
 impl<'a> egui::Widget for Vec2Widget<'a> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
         ui.push_id(self.id_hash, |ui| {
-            let mut total_size = ui.available_size();
-            total_size.x = self.width;
+            let slot_height = ui.spacing().interact_size.y;
+            let slot_width = ui.available_width().min(self.width);
             ui.horizontal(|ui| {
                 let x_id = ui.id().with(self.id_hash).with("vec3 x");
                 let y_id = ui.id().with(self.id_hash).with("vec3 y");
@@ -42,7 +42,7 @@ impl<'a> egui::Widget for Vec2Widget<'a> {
                 let x_response = ui
                     .push_id(x_id, |ui| {
                         ui.add_sized(
-                            egui::Vec2::new(total_size.x / 3.1, total_size.y),
+                            egui::Vec2::new(slot_width / 3.1, slot_height),
                             egui::DragValue::new(&mut self.vec2.x).speed(self.slider_step_size),
                         )
                     })
@@ -50,7 +50,7 @@ impl<'a> egui::Widget for Vec2Widget<'a> {
                 let y_response = ui
                     .push_id(y_id, |ui| {
                         ui.add_sized(
-                            egui::Vec2::new(total_size.x / 3.1, total_size.y),
+                            egui::Vec2::new(slot_width / 3.1, slot_height),
                             egui::DragValue::new(&mut self.vec2.y).speed(self.slider_step_size),
                         )
                     })

--- a/crates/bevy_animation_graph_editor/src/ui/generic_widgets/vec3.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/generic_widgets/vec3.rs
@@ -31,8 +31,8 @@ impl<'a> Vec3Widget<'a> {
 impl<'a> egui::Widget for Vec3Widget<'a> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
         ui.push_id(self.id_hash, |ui| {
-            let mut total_size = ui.available_size();
-            total_size.x = self.width;
+            let slot_height = ui.spacing().interact_size.y;
+            let slot_width = ui.available_width().min(self.width);
             ui.horizontal(|ui| {
                 let x_id = ui.id().with(self.id_hash).with("vec3 x");
                 let y_id = ui.id().with(self.id_hash).with("vec3 y");
@@ -41,7 +41,7 @@ impl<'a> egui::Widget for Vec3Widget<'a> {
                 let x_response = ui
                     .push_id(x_id, |ui| {
                         ui.add_sized(
-                            egui::Vec2::new(total_size.x / 3.1, total_size.y),
+                            egui::Vec2::new(slot_width / 3.1, slot_height),
                             egui::DragValue::new(&mut self.vec3.x).speed(self.slider_step_size),
                         )
                     })
@@ -49,7 +49,7 @@ impl<'a> egui::Widget for Vec3Widget<'a> {
                 let y_response = ui
                     .push_id(y_id, |ui| {
                         ui.add_sized(
-                            egui::Vec2::new(total_size.x / 3.1, total_size.y),
+                            egui::Vec2::new(slot_width / 3.1, slot_height),
                             egui::DragValue::new(&mut self.vec3.y).speed(self.slider_step_size),
                         )
                     })
@@ -57,7 +57,7 @@ impl<'a> egui::Widget for Vec3Widget<'a> {
                 let z_response = ui
                     .push_id(z_id, |ui| {
                         ui.add_sized(
-                            egui::Vec2::new(total_size.x / 3.1, total_size.y),
+                            egui::Vec2::new(slot_width / 3.1, slot_height),
                             egui::DragValue::new(&mut self.vec3.z).speed(self.slider_step_size),
                         )
                     })


### PR DESCRIPTION
this PR changes the way column sizes are calculated inside the inspector to be more responsive to the panel width. I tried using eguis TableBuilder but did not get the resizing to work properly, this might be a kind of hacky approach. Also includes catching a debug assertion from egui that would otherwise sometimes lead to crashes when moving a float drag handle.