### PR TITLE
feat: add boolean logic nodes (Not, And, Or)

### DIFF
--- a/crates/bevy_animation_graph_builtin_nodes/src/bool/and_bool.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/bool/and_bool.rs
@@ -1,0 +1,42 @@
+use bevy::prelude::*;
+use bevy_animation_graph_core::{
+    animation_node::{NodeLike, ReflectNodeLike},
+    context::{new_context::NodeContext, spec_context::SpecContext},
+    edge_data::DataSpec,
+    errors::GraphError,
+};
+
+#[derive(Reflect, Clone, Debug, Default)]
+#[reflect(Default, NodeLike)]
+#[type_path = "bevy_animation_graph::builtin_nodes"]
+pub struct AndBool;
+
+impl AndBool {
+    pub const INPUT_A: &'static str = "in_a";
+    pub const INPUT_B: &'static str = "in_b";
+    pub const OUTPUT: &'static str = "out";
+
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl NodeLike for AndBool {
+    fn display_name(&self) -> String {
+        "&& And".into()
+    }
+
+    fn update(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
+        let a = ctx.data_back(Self::INPUT_A)?.as_bool()?;
+        let b = ctx.data_back(Self::INPUT_B)?.as_bool()?;
+        ctx.set_data_fwd(Self::OUTPUT, a && b);
+        Ok(())
+    }
+
+    fn spec(&self, mut ctx: SpecContext) -> Result<(), GraphError> {
+        ctx.add_input_data(Self::INPUT_A, DataSpec::Bool)
+            .add_input_data(Self::INPUT_B, DataSpec::Bool)
+            .add_output_data(Self::OUTPUT, DataSpec::Bool);
+        Ok(())
+    }
+}

--- a/crates/bevy_animation_graph_builtin_nodes/src/bool/mod.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/bool/mod.rs
@@ -1,1 +1,4 @@
+pub mod and_bool;
 pub mod const_bool;
+pub mod not_bool;
+pub mod or_bool;

--- a/crates/bevy_animation_graph_builtin_nodes/src/bool/not_bool.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/bool/not_bool.rs
@@ -1,0 +1,39 @@
+use bevy::prelude::*;
+use bevy_animation_graph_core::{
+    animation_node::{NodeLike, ReflectNodeLike},
+    context::{new_context::NodeContext, spec_context::SpecContext},
+    edge_data::DataSpec,
+    errors::GraphError,
+};
+
+#[derive(Reflect, Clone, Debug, Default)]
+#[reflect(Default, NodeLike)]
+#[type_path = "bevy_animation_graph::builtin_nodes"]
+pub struct NotBool;
+
+impl NotBool {
+    pub const INPUT: &'static str = "in";
+    pub const OUTPUT: &'static str = "out";
+
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl NodeLike for NotBool {
+    fn display_name(&self) -> String {
+        "! Not".into()
+    }
+
+    fn update(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
+        let input = ctx.data_back(Self::INPUT)?.as_bool()?;
+        ctx.set_data_fwd(Self::OUTPUT, !input);
+        Ok(())
+    }
+
+    fn spec(&self, mut ctx: SpecContext) -> Result<(), GraphError> {
+        ctx.add_input_data(Self::INPUT, DataSpec::Bool)
+            .add_output_data(Self::OUTPUT, DataSpec::Bool);
+        Ok(())
+    }
+}

--- a/crates/bevy_animation_graph_builtin_nodes/src/bool/or_bool.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/bool/or_bool.rs
@@ -1,0 +1,42 @@
+use bevy::prelude::*;
+use bevy_animation_graph_core::{
+    animation_node::{NodeLike, ReflectNodeLike},
+    context::{new_context::NodeContext, spec_context::SpecContext},
+    edge_data::DataSpec,
+    errors::GraphError,
+};
+
+#[derive(Reflect, Clone, Debug, Default)]
+#[reflect(Default, NodeLike)]
+#[type_path = "bevy_animation_graph::builtin_nodes"]
+pub struct OrBool;
+
+impl OrBool {
+    pub const INPUT_A: &'static str = "in_a";
+    pub const INPUT_B: &'static str = "in_b";
+    pub const OUTPUT: &'static str = "out";
+
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl NodeLike for OrBool {
+    fn display_name(&self) -> String {
+        "|| Or".into()
+    }
+
+    fn update(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
+        let a = ctx.data_back(Self::INPUT_A)?.as_bool()?;
+        let b = ctx.data_back(Self::INPUT_B)?.as_bool()?;
+        ctx.set_data_fwd(Self::OUTPUT, a || b);
+        Ok(())
+    }
+
+    fn spec(&self, mut ctx: SpecContext) -> Result<(), GraphError> {
+        ctx.add_input_data(Self::INPUT_A, DataSpec::Bool)
+            .add_input_data(Self::INPUT_B, DataSpec::Bool)
+            .add_output_data(Self::OUTPUT, DataSpec::Bool);
+        Ok(())
+    }
+}

--- a/crates/bevy_animation_graph_builtin_nodes/src/lib.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/lib.rs
@@ -3,6 +3,7 @@ use bevy::app::{App, Plugin};
 use crate::{
     blend_node::BlendNode,
     blend_space_node::BlendSpaceNode,
+    bool::{and_bool::AndBool, const_bool::ConstBool, not_bool::NotBool, or_bool::OrBool},
     chain_node::ChainNode,
     clip_node::ClipNode,
     dummy_node::DummyNode,
@@ -75,6 +76,11 @@ impl BuiltinNodesPlugin {
             .register_type::<SpeedNode>()
             .register_type::<FsmNode>()
             .register_type::<TwoBoneIKNode>()
+            // bool
+            .register_type::<AndBool>()
+            .register_type::<ConstBool>()
+            .register_type::<NotBool>()
+            .register_type::<OrBool>()
             // f32
             .register_type::<AbsF32>()
             .register_type::<AddF32>()

--- a/release-content/release-notes/bool_logic_nodes.md
+++ b/release-content/release-notes/bool_logic_nodes.md
@@ -1,0 +1,13 @@
+---
+title: Boolean Logic Nodes
+authors: ["@baszalmstra"]
+pull_requests: []
+---
+
+Three new boolean logic nodes have been added to complement the existing `ConstBool` node:
+
+- **`NotBool`** (`! Not`): Logical NOT — inverts a boolean input
+- **`AndBool`** (`&& And`): Logical AND — true only when both inputs are true
+- **`OrBool`** (`|| Or`): Logical OR — true when either input is true
+
+These enable combining boolean conditions within the graph — e.g. `is_grounded AND is_moving` to drive blend parameters or FSM transitions.

--- a/release-content/release-notes/bool_logic_nodes.md
+++ b/release-content/release-notes/bool_logic_nodes.md
@@ -1,7 +1,7 @@
 ---
 title: Boolean Logic Nodes
 authors: ["@baszalmstra"]
-pull_requests: []
+pull_requests: [132]
 ---
 
 Three new boolean logic nodes have been added to complement the existing `ConstBool` node:


### PR DESCRIPTION
This PR adds boolean logic nodes to the builtin nodes library. Currently the only boolean node is `ConstBool`, which means there's no way to do any boolean operations within the graph. These three nodes fill that gap.

### What it does

Three new nodes in the `bool` module:

- **`NotBool`** (`! Not`): Logical NOT — inverts a boolean input
- **`AndBool`** (`&& And`): Logical AND — true only when both inputs are true
- **`OrBool`** (`|| Or`): Logical OR — true when either input is true

### AI Disclosure

I used AI (Claude Code) to generate the node implementations.