### PR TITLE
feat: add BlendSpace1D node

### DIFF
--- a/crates/bevy_animation_graph_builtin_nodes/src/blend_space_1d_node.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/blend_space_1d_node.rs
@@ -1,0 +1,233 @@
+use bevy::prelude::*;
+use bevy_animation_graph_core::{
+    animation_graph::TimeUpdate,
+    animation_node::{EditProxy, NodeLike, ReflectEditProxy, ReflectNodeLike},
+    context::{new_context::NodeContext, spec_context::SpecContext},
+    edge_data::DataSpec,
+    errors::GraphError,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::blend_node::BlendSyncMode;
+
+#[derive(Reflect, Clone, Debug, Default, Serialize, Deserialize)]
+#[reflect(Default, Serialize, Deserialize)]
+pub struct PointElement1D {
+    pub id: String,
+    pub value: f32,
+}
+
+/// Blends between poses arranged along a single axis. At runtime, the two nearest
+/// points to the `parameter` input are found and linearly interpolated.
+///
+/// Points should be sorted by value for correct behavior. If the parameter falls
+/// outside the range, it is clamped to the nearest endpoint.
+///
+/// This node is useful, for example, to blend between idle, walk, and run
+/// animations based on movement speed.
+#[derive(Reflect, Clone, Debug, Default)]
+#[reflect(Default, NodeLike, EditProxy)]
+#[type_path = "bevy_animation_graph::builtin_nodes"]
+pub struct BlendSpace1DNode {
+    pub sync_mode: BlendSyncMode,
+    pub points: Vec<PointElement1D>,
+}
+
+impl BlendSpace1DNode {
+    pub const PARAMETER: &'static str = "parameter";
+    pub const OUT_POSE: &'static str = "pose";
+
+    pub fn new(sync_mode: BlendSyncMode, points: Vec<PointElement1D>) -> Self {
+        Self { sync_mode, points }
+    }
+
+    pub fn pose_pin_id(key: &str) -> String {
+        format!("pose {key}")
+    }
+
+    pub fn events_pin_id(key: &str) -> String {
+        format!("events {key}")
+    }
+
+    pub fn time_pin_id(key: &str) -> String {
+        format!("time {key}")
+    }
+
+    /// Finds the two surrounding points and returns (index_low, index_high, blend_factor).
+    /// The blend factor is 0.0 at the low point and 1.0 at the high point.
+    /// If the parameter is outside the range, clamps to the nearest endpoint.
+    fn find_blend_pair(&self, parameter: f32) -> (usize, usize, f32) {
+        let n = self.points.len();
+        assert!(n >= 2, "BlendSpace1D requires at least 2 points");
+
+        // Clamp below the first point
+        if parameter <= self.points[0].value {
+            return (0, 0, 0.0);
+        }
+
+        // Clamp above the last point
+        if parameter >= self.points[n - 1].value {
+            return (n - 1, n - 1, 0.0);
+        }
+
+        // Find the segment containing the parameter
+        for i in 0..n - 1 {
+            let low = self.points[i].value;
+            let high = self.points[i + 1].value;
+            if parameter >= low && parameter <= high {
+                let range = high - low;
+                let factor = if range > f32::EPSILON {
+                    (parameter - low) / range
+                } else {
+                    0.0
+                };
+                return (i, i + 1, factor);
+            }
+        }
+
+        // Fallback (shouldn't reach here with sorted points)
+        (n - 1, n - 1, 0.0)
+    }
+}
+
+impl NodeLike for BlendSpace1DNode {
+    fn duration(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
+        let parameter = ctx.data_back(Self::PARAMETER)?.as_f32()?;
+        let (low, high, factor) = self.find_blend_pair(parameter);
+
+        // Return the duration of the higher-weighted input
+        let master_idx = if factor <= 0.5 { low } else { high };
+        let master_duration =
+            ctx.duration_back(Self::time_pin_id(&self.points[master_idx].id))?;
+
+        ctx.set_duration_fwd(master_duration);
+        Ok(())
+    }
+
+    fn update(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
+        let input = ctx.time_update_fwd()?;
+        let parameter = ctx.data_back(Self::PARAMETER)?.as_f32()?;
+        let (low_idx, high_idx, factor) = self.find_blend_pair(parameter);
+
+        let low_key = &self.points[low_idx].id;
+        let high_key = &self.points[high_idx].id;
+
+        // Evaluate the primary (higher-weighted) input first
+        let (primary_key, secondary_key, primary_factor, secondary_factor) = if factor <= 0.5 {
+            (low_key, high_key, 1.0 - factor, factor)
+        } else {
+            (high_key, low_key, factor, 1.0 - factor)
+        };
+
+        ctx.set_time_update_back(Self::time_pin_id(primary_key), input.clone());
+        let primary_pose = ctx
+            .data_back(Self::pose_pin_id(primary_key))?
+            .into_pose()?;
+
+        // If both indices are the same, just output the single pose
+        if low_idx == high_idx {
+            ctx.set_time(primary_pose.timestamp);
+            ctx.set_data_fwd(Self::OUT_POSE, primary_pose);
+            return Ok(());
+        }
+
+        // Set time for secondary input based on sync mode
+        match &self.sync_mode {
+            BlendSyncMode::Absolute => {
+                ctx.set_time_update_back(
+                    Self::time_pin_id(secondary_key),
+                    TimeUpdate::Absolute(primary_pose.timestamp),
+                );
+            }
+            BlendSyncMode::NoSync => {
+                ctx.set_time_update_back(Self::time_pin_id(secondary_key), input);
+            }
+            BlendSyncMode::EventTrack(track_name) => {
+                let event_queue = ctx
+                    .data_back(Self::events_pin_id(primary_key))?
+                    .into_event_queue()?;
+                if let Some(event) = event_queue.events.iter().find(|ev| {
+                    ev.track
+                        .as_ref()
+                        .map(|track| track == track_name)
+                        .unwrap_or(false)
+                }) {
+                    ctx.set_time_update_back(
+                        Self::time_pin_id(secondary_key),
+                        TimeUpdate::PercentOfEvent {
+                            percent: event.percentage,
+                            event: event.event.clone(),
+                            track: track_name.clone(),
+                        },
+                    );
+                } else {
+                    ctx.set_time_update_back(Self::time_pin_id(secondary_key), input);
+                }
+            }
+        };
+
+        let secondary_pose = ctx
+            .data_back(Self::pose_pin_id(secondary_key))?
+            .into_pose()?;
+
+        let out_pose = [
+            (&primary_pose, primary_factor),
+            (&secondary_pose, secondary_factor),
+        ]
+        .into_iter()
+        .map(|(pose, f)| pose.scalar_mult(f))
+        .reduce(|acc, elem| acc.linear_add(&elem))
+        .unwrap()
+        .normalize_quat();
+
+        ctx.set_time(primary_pose.timestamp);
+        ctx.set_data_fwd(Self::OUT_POSE, out_pose);
+
+        Ok(())
+    }
+
+    fn spec(&self, mut ctx: SpecContext) -> Result<(), GraphError> {
+        ctx.add_input_data(Self::PARAMETER, DataSpec::F32);
+
+        for p in &self.points {
+            ctx.add_input_data(Self::pose_pin_id(&p.id), DataSpec::Pose);
+            if matches!(&self.sync_mode, BlendSyncMode::EventTrack(_)) {
+                ctx.add_input_data(Self::events_pin_id(&p.id), DataSpec::EventQueue);
+            }
+            ctx.add_input_time(Self::time_pin_id(&p.id));
+        }
+
+        ctx.add_output_data(Self::OUT_POSE, DataSpec::Pose)
+            .add_output_time();
+
+        Ok(())
+    }
+
+    fn display_name(&self) -> String {
+        "∑ Blend space 1D".into()
+    }
+}
+
+#[derive(Clone, Reflect, Serialize, Deserialize)]
+pub struct BlendSpace1DProxy {
+    pub sync_mode: BlendSyncMode,
+    pub points: Vec<PointElement1D>,
+}
+
+impl EditProxy for BlendSpace1DNode {
+    type Proxy = BlendSpace1DProxy;
+
+    fn update_from_proxy(proxy: &Self::Proxy) -> Self {
+        Self {
+            sync_mode: proxy.sync_mode.clone(),
+            points: proxy.points.clone(),
+        }
+    }
+
+    fn make_proxy(&self) -> Self::Proxy {
+        Self::Proxy {
+            sync_mode: self.sync_mode.clone(),
+            points: self.points.clone(),
+        }
+    }
+}

--- a/crates/bevy_animation_graph_builtin_nodes/src/blend_space_1d_node.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/blend_space_1d_node.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_animation_graph_core::{
     animation_graph::TimeUpdate,
-    animation_node::{EditProxy, NodeLike, ReflectEditProxy, ReflectNodeLike},
+    animation_node::{NodeLike, ReflectNodeLike},
     context::{new_context::NodeContext, spec_context::SpecContext},
     edge_data::DataSpec,
     errors::GraphError,
@@ -26,7 +26,7 @@ pub struct PointElement1D {
 /// This node is useful, for example, to blend between idle, walk, and run
 /// animations based on movement speed.
 #[derive(Reflect, Clone, Debug, Default)]
-#[reflect(Default, NodeLike, EditProxy)]
+#[reflect(Default, NodeLike)]
 #[type_path = "bevy_animation_graph::builtin_nodes"]
 pub struct BlendSpace1DNode {
     pub sync_mode: BlendSyncMode,
@@ -42,15 +42,15 @@ impl BlendSpace1DNode {
     }
 
     pub fn pose_pin_id(key: &str) -> String {
-        format!("pose {key}")
+        format!("pose_{key}")
     }
 
     pub fn events_pin_id(key: &str) -> String {
-        format!("events {key}")
+        format!("events_{key}")
     }
 
     pub fn time_pin_id(key: &str) -> String {
-        format!("time {key}")
+        format!("time_{key}")
     }
 
     /// Finds the two surrounding points and returns (index_low, index_high, blend_factor).
@@ -209,29 +209,5 @@ impl NodeLike for BlendSpace1DNode {
 
     fn display_name(&self) -> String {
         "∑ Blend space 1D".into()
-    }
-}
-
-#[derive(Clone, Reflect, Serialize, Deserialize)]
-pub struct BlendSpace1DProxy {
-    pub sync_mode: BlendSyncMode,
-    pub points: Vec<PointElement1D>,
-}
-
-impl EditProxy for BlendSpace1DNode {
-    type Proxy = BlendSpace1DProxy;
-
-    fn update_from_proxy(proxy: &Self::Proxy) -> Self {
-        Self {
-            sync_mode: proxy.sync_mode.clone(),
-            points: proxy.points.clone(),
-        }
-    }
-
-    fn make_proxy(&self) -> Self::Proxy {
-        Self::Proxy {
-            sync_mode: self.sync_mode.clone(),
-            points: self.points.clone(),
-        }
     }
 }

--- a/crates/bevy_animation_graph_builtin_nodes/src/blend_space_1d_node.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/blend_space_1d_node.rs
@@ -56,18 +56,21 @@ impl BlendSpace1DNode {
     /// Finds the two surrounding points and returns (index_low, index_high, blend_factor).
     /// The blend factor is 0.0 at the low point and 1.0 at the high point.
     /// If the parameter is outside the range, clamps to the nearest endpoint.
-    fn find_blend_pair(&self, parameter: f32) -> (usize, usize, f32) {
+    /// Returns `None` if there are fewer than 2 points.
+    fn find_blend_pair(&self, parameter: f32) -> Option<(usize, usize, f32)> {
         let n = self.points.len();
-        assert!(n >= 2, "BlendSpace1D requires at least 2 points");
+        if n < 2 {
+            return None;
+        }
 
         // Clamp below the first point
         if parameter <= self.points[0].value {
-            return (0, 0, 0.0);
+            return Some((0, 0, 0.0));
         }
 
         // Clamp above the last point
         if parameter >= self.points[n - 1].value {
-            return (n - 1, n - 1, 0.0);
+            return Some((n - 1, n - 1, 0.0));
         }
 
         // Find the segment containing the parameter
@@ -81,19 +84,21 @@ impl BlendSpace1DNode {
                 } else {
                     0.0
                 };
-                return (i, i + 1, factor);
+                return Some((i, i + 1, factor));
             }
         }
 
         // Fallback (shouldn't reach here with sorted points)
-        (n - 1, n - 1, 0.0)
+        Some((n - 1, n - 1, 0.0))
     }
 }
 
 impl NodeLike for BlendSpace1DNode {
     fn duration(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
         let parameter = ctx.data_back(Self::PARAMETER)?.as_f32()?;
-        let (low, high, factor) = self.find_blend_pair(parameter);
+        let Some((low, high, factor)) = self.find_blend_pair(parameter) else {
+            return Ok(());
+        };
 
         // Return the duration of the higher-weighted input
         let master_idx = if factor <= 0.5 { low } else { high };
@@ -107,7 +112,9 @@ impl NodeLike for BlendSpace1DNode {
     fn update(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
         let input = ctx.time_update_fwd()?;
         let parameter = ctx.data_back(Self::PARAMETER)?.as_f32()?;
-        let (low_idx, high_idx, factor) = self.find_blend_pair(parameter);
+        let Some((low_idx, high_idx, factor)) = self.find_blend_pair(parameter) else {
+            return Ok(());
+        };
 
         let low_key = &self.points[low_idx].id;
         let high_key = &self.points[high_idx].id;

--- a/crates/bevy_animation_graph_builtin_nodes/src/blend_space_1d_node.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/blend_space_1d_node.rs
@@ -102,8 +102,7 @@ impl NodeLike for BlendSpace1DNode {
 
         // Return the duration of the higher-weighted input
         let master_idx = if factor <= 0.5 { low } else { high };
-        let master_duration =
-            ctx.duration_back(Self::time_pin_id(&self.points[master_idx].id))?;
+        let master_duration = ctx.duration_back(Self::time_pin_id(&self.points[master_idx].id))?;
 
         ctx.set_duration_fwd(master_duration);
         Ok(())
@@ -127,9 +126,7 @@ impl NodeLike for BlendSpace1DNode {
         };
 
         ctx.set_time_update_back(Self::time_pin_id(primary_key), input.clone());
-        let primary_pose = ctx
-            .data_back(Self::pose_pin_id(primary_key))?
-            .into_pose()?;
+        let primary_pose = ctx.data_back(Self::pose_pin_id(primary_key))?.into_pose()?;
 
         // If both indices are the same, just output the single pose
         if low_idx == high_idx {

--- a/crates/bevy_animation_graph_builtin_nodes/src/lib.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/lib.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 
 pub mod blend_node;
+pub mod blend_space_1d_node;
 pub mod blend_space_node;
 pub mod bool;
 pub mod chain_node;

--- a/crates/bevy_animation_graph_builtin_nodes/src/lib.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/lib.rs
@@ -2,6 +2,7 @@ use bevy::app::{App, Plugin};
 
 use crate::{
     blend_node::BlendNode,
+    blend_space_1d_node::BlendSpace1DNode,
     blend_space_node::BlendSpaceNode,
     chain_node::ChainNode,
     clip_node::ClipNode,
@@ -66,6 +67,7 @@ impl BuiltinNodesPlugin {
             .register_type::<DummyNode>()
             .register_type::<ChainNode>()
             .register_type::<BlendNode>()
+            .register_type::<BlendSpace1DNode>()
             .register_type::<BlendSpaceNode>()
             .register_type::<FlipLRNode>()
             .register_type::<ReplicateTimeNode>()

--- a/release-content/release-notes/blend_space_1d.md
+++ b/release-content/release-notes/blend_space_1d.md
@@ -1,7 +1,7 @@
 ---
 title: Blend Space 1D Node
 authors: ["@baszalmstra"]
-pull_requests: []
+pull_requests: [134]
 ---
 
 A new `BlendSpace1DNode` has been added for single-axis parametric blending. This complements the existing 2D blend space node and is useful for common cases like blending between idle, walk, and run animations based on movement speed.

--- a/release-content/release-notes/blend_space_1d.md
+++ b/release-content/release-notes/blend_space_1d.md
@@ -1,0 +1,22 @@
+---
+title: Blend Space 1D Node
+authors: ["@baszalmstra"]
+pull_requests: []
+---
+
+A new `BlendSpace1DNode` has been added for single-axis parametric blending. This complements the existing 2D blend space node and is useful for common cases like blending between idle, walk, and run animations based on movement speed.
+
+Configure the node with a list of named points along a single axis:
+
+```ron
+BlendSpace1DNode: (
+    sync_mode: Absolute,
+    points: [
+        (id: "idle", value: 0.0),
+        (id: "walk", value: 1.71),
+        (id: "run",  value: 4.55),
+    ],
+)
+```
+
+At runtime, the node finds the two nearest points to the `parameter` input and linearly interpolates between them. All sync modes from the 2D blend space (Absolute, NoSync, EventTrack) are supported.


### PR DESCRIPTION
Sorry to overwhelm you with PRs! I have been setting these up as I went along integrating this amazing crate in my project. 😅

This PR adds a `BlendSpace1DNode` for single-axis parametric blending, complementing the existing 2D blend space node.

### What it does

The node blends between poses arranged along a single axis. You configure it with named points at specific values, and at runtime it finds the two nearest points to the `parameter` input and linearly interpolates between them.

Example config for idle/walk/run locomotion:

```ron
BlendSpace1DNode: (
    sync_mode: Absolute,
    points: [
        (id: "idle", value: 0.0),
        (id: "walk", value: 1.71),
        (id: "run",  value: 4.55),
    ],
)
```

Dynamic pins are created for each point (`pose idle`, `time idle`, etc.), following the same pattern as `BlendSpaceNode` (2D). All three sync modes are supported: `Absolute`, `NoSync`, and `EventTrack`.

### Why this matters

Without this node, a simple idle/walk/run blend requires ~20 math nodes to manually compute blend factors (`Sub`, `Div`, `Clamp` per transition, plus speed factor logic). With `BlendSpace1DNode` this becomes a single node with a speed input.

Every major engine has a 1D blend space equivalent: Unreal's Blend Space 1D, Unity's 1D Blend Trees, Godot's BlendSpace1D, and Esoterica's Blend1DNode.

I ran into this gap when trying out the crate for a locomotion blend and ended up building the blend factors manually with ~20 math nodes. I may be missing context on why a 1D node wasn't added alongside the 2D one. If there was a deliberate reason or an existing way to achieve this that I overlooked, let me know.

### Naming question

The existing 2D blend space is called `BlendSpaceNode` (without a "2D" suffix). Should we rename it to `BlendSpace2DNode` for consistency now that a 1D variant exists? Or keep it as-is to avoid breaking existing graphs? Happy to do the rename in this PR or a follow-up if desired.

### AI Disclosure

I used AI (Claude Code) to research missing nodes across other engines and to generate the implementation.