### PR TITLE
feat: add generic constants node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
  "egui-notify",
  "egui_dock",
  "egui_extras",
- "rand 0.9.4",
+ "rand 0.10.1",
  "ron 0.10.1",
  "serde",
  "uuid",
@@ -2205,6 +2205,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2239,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2740,7 +2751,7 @@ dependencies = [
  "bevy",
  "bevy_animation_graph",
  "bevy_animation_graph_editor",
- "rand 0.8.5",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -3266,6 +3277,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3776,7 +3788,7 @@ dependencies = [
  "bevy",
  "bevy-inspector-egui",
  "bevy_animation_graph",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
 ]
 
@@ -5374,9 +5386,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -5484,9 +5496,9 @@ checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-error"
@@ -5536,8 +5548,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -5547,18 +5557,19 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5576,9 +5587,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -5588,6 +5596,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -6781,9 +6795,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7073,9 +7087,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
  "jni 0.22.4",
@@ -7093,14 +7107,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ bevy_egui = { version = "0.39" }
 bevy-inspector-egui = { version = "0.36" }
 
 ron = "0.10.1"
-serde = { version = "1.0" }
+serde = "1.0"
+rand = "0.10"

--- a/crates/bevy_animation_graph_builtin_nodes/src/constants.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/constants.rs
@@ -1,0 +1,38 @@
+use bevy::prelude::*;
+use bevy_animation_graph_core::{
+    animation_graph::PinId,
+    animation_node::{NodeLike, ReflectNodeLike},
+    context::{new_context::NodeContext, spec_context::SpecContext},
+    edge_data::DataValue,
+    errors::GraphError,
+    utils::sorted_map::SortedMap,
+};
+
+#[derive(Reflect, Clone, Debug, Default)]
+#[reflect(Default, NodeLike)]
+#[type_path = "bevy_animation_graph::builtin_nodes"]
+pub struct Constants {
+    pub constants: SortedMap<PinId, DataValue>,
+}
+
+impl NodeLike for Constants {
+    fn display_name(&self) -> String {
+        "Constants".into()
+    }
+
+    fn update(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
+        for (k, v) in self.constants.iter() {
+            ctx.set_data_fwd(k, v.clone());
+        }
+
+        Ok(())
+    }
+
+    fn spec(&self, mut ctx: SpecContext) -> Result<(), GraphError> {
+        for (k, v) in self.constants.iter() {
+            ctx.add_output_data(k, v.into());
+        }
+
+        Ok(())
+    }
+}

--- a/crates/bevy_animation_graph_builtin_nodes/src/lib.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/lib.rs
@@ -7,6 +7,7 @@ use crate::{
     bool::{and_bool::AndBool, const_bool::ConstBool, not_bool::NotBool, or_bool::OrBool},
     chain_node::ChainNode,
     clip_node::ClipNode,
+    constants::Constants,
     dummy_node::DummyNode,
     event_queue::{
         fire_event::FireEventNode, map_events::MapEventsNode, merge_event_queues::MergeEventQueues,
@@ -35,6 +36,7 @@ pub mod bool;
 pub mod chain_node;
 pub mod clip_node;
 pub mod const_entity_path;
+pub mod constants;
 pub mod dummy_node;
 pub mod event_markup_node;
 pub mod event_queue;
@@ -80,6 +82,7 @@ impl BuiltinNodesPlugin {
             .register_type::<SpeedNode>()
             .register_type::<FsmNode>()
             .register_type::<TwoBoneIKNode>()
+            .register_type::<Constants>()
             // bool
             .register_type::<AndBool>()
             .register_type::<ConstBool>()

--- a/crates/bevy_animation_graph_editor/Cargo.toml
+++ b/crates/bevy_animation_graph_editor/Cargo.toml
@@ -28,7 +28,7 @@ bevy_egui = { workspace = true }
 bevy-inspector-egui = { workspace = true }
 avian3d = { workspace = true, optional = true }
 
-rand = "0.9.0"
+rand = { workspace = true }
 uuid = { version = "1.16.0", features = ["v4"] }
 bitflags = "2.10.0"
 

--- a/crates/bevy_animation_graph_editor/src/egui_nodes/lib.rs
+++ b/crates/bevy_animation_graph_editor/src/egui_nodes/lib.rs
@@ -606,7 +606,7 @@ impl NodesContext {
                         .inner_margin(egui::vec2(1.5, 1.5))
                         .corner_radius(3.0)
                         .stroke(egui::Stroke::new(
-                            1.0,
+                            1.0_f32,
                             self.settings.style.colors[if node.spec.active {
                                 ColorStyle::NodeOutlineActive
                             } else {

--- a/crates/bevy_animation_graph_editor/src/ui/native_windows/event_sender.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/native_windows/event_sender.rs
@@ -23,7 +23,7 @@ impl NativeEditorWindowExtension for EventSenderWindow {
         ui.horizontal_wrapped(|ui| {
             buffer.events.retain(|ev| {
                 egui::Frame::NONE
-                    .stroke(egui::Stroke::new(1., egui::Color32::WHITE))
+                    .stroke(egui::Stroke::new(1.0_f32, egui::Color32::WHITE))
                     .show(ui, |ui| {
                         ui.horizontal(|ui| {
                             if ui.button(format!("{ev:?}")).clicked() {

--- a/crates/bevy_animation_graph_editor/src/ui/native_windows/event_track_editor.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/native_windows/event_track_editor.rs
@@ -541,7 +541,7 @@ impl EventTrackEditorState {
             let path_shape = egui::epaint::PathShape::convex_polygon(
                 points,
                 egui::Color32::RED, // fill color for the triangle
-                egui::Stroke::new(0.0, egui::Color32::TRANSPARENT),
+                egui::Stroke::new(0.0_f32, egui::Color32::TRANSPARENT),
             );
 
             ui.painter().add(egui::Shape::Path(path_shape));

--- a/crates/bevy_animation_graph_editor/src/ui/native_windows/fsm_editor.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/native_windows/fsm_editor.rs
@@ -703,7 +703,7 @@ impl FsmEditorWindowState {
             ],
             closed: true,
             fill: style.bg.unwrap_or_default(),
-            stroke: egui::epaint::PathStroke::new(0., egui::Color32::TRANSPARENT),
+            stroke: egui::epaint::PathStroke::new(0.0_f32, egui::Color32::TRANSPARENT),
         });
 
         ui.painter().add(egui::epaint::PathShape {
@@ -714,7 +714,7 @@ impl FsmEditorWindowState {
             ],
             closed: true,
             fill: style.bg.unwrap_or_default(),
-            stroke: egui::epaint::PathStroke::new(0., egui::Color32::TRANSPARENT),
+            stroke: egui::epaint::PathStroke::new(0.0_f32, egui::Color32::TRANSPARENT),
         });
 
         // arrow outline

--- a/crates/bevy_animation_graph_editor/src/ui/node_editors/mod.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/node_editors/mod.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use bevy::{app::App, ecs::world::World, reflect::FromType};
 use bevy_animation_graph::{
     builtin_nodes::{
-        blend_space_node::BlendSpaceNode, global_input::GlobalInput,
+        blend_space_node::BlendSpaceNode, constants::Constants, global_input::GlobalInput,
         ragdoll::const_ragdoll_config::ConstRagdollConfig,
     },
     core::animation_node::NodeLike,
@@ -86,8 +86,18 @@ impl Editable for GlobalInput {
         NewReflectNodeEditor
     }
 }
+
+impl Editable for Constants {
+    type Editor = NewReflectNodeEditor;
+
+    fn get_editor(&self) -> Self::Editor {
+        NewReflectNodeEditor
+    }
+}
+
 pub fn register_node_editables(app: &mut App) {
     app.register_type_data::<ConstRagdollConfig, ReflectEditable>();
     app.register_type_data::<BlendSpaceNode, ReflectEditable>();
     app.register_type_data::<GlobalInput, ReflectEditable>();
+    app.register_type_data::<Constants, ReflectEditable>();
 }

--- a/crates/bevy_animation_graph_editor/src/ui/reflect_widgets/mod.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/reflect_widgets/mod.rs
@@ -1,4 +1,7 @@
-use bevy_animation_graph::core::{animation_graph::PinId, edge_data::DataSpecWithOptionalDefault};
+use bevy_animation_graph::core::{
+    animation_graph::PinId,
+    edge_data::{DataSpecWithOptionalDefault, DataValue},
+};
 
 use crate::ui::{
     reflect_lib::WidgetRegistry,
@@ -19,6 +22,7 @@ pub fn register_reflect_widgets(registry: &mut WidgetRegistry) {
     registry
         .add(HashMapReflectWidget::<String, String>::default())
         .add(SortedMapReflectWidget::<PinId, DataSpecWithOptionalDefault>::default())
+        .add(SortedMapReflectWidget::<PinId, DataValue>::default())
         .add(DataValueReflectWidget)
         .add(Vec3ReflectWidget)
         .add(RagdollConfigReflectWidget);

--- a/examples/editor_as_a_plugin/Cargo.toml
+++ b/examples/editor_as_a_plugin/Cargo.toml
@@ -7,4 +7,4 @@ edition = { workspace = true }
 bevy = { workspace = true }
 bevy_animation_graph = { path = "../../crates/bevy_animation_graph" }
 bevy_animation_graph_editor = { path = "../../crates/bevy_animation_graph_editor" }
-rand = "0.8"
+rand = { workspace = true }

--- a/examples/human_ragdoll/Cargo.toml
+++ b/examples/human_ragdoll/Cargo.toml
@@ -10,5 +10,5 @@ bevy_animation_graph = { path = "../../crates/bevy_animation_graph", features = 
 ] }
 avian3d = { workspace = true }
 serde = { workspace = true }
-rand = "0.9.2"
+rand = { workspace = true }
 bevy-inspector-egui = { workspace = true }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1774753967,
-        "narHash": "sha256-HpT5fE8JQSbAxolUnw3VgGAo3urVjcrgtB2rtoxURVw=",
+        "lastModified": 1776350315,
+        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "405b9b4c2c6c5a2b1d390524ce8a240729f34a96",
+        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
         "type": "github"
       },
       "original": {

--- a/release-content/release-notes/generic_constants_node.md
+++ b/release-content/release-notes/generic_constants_node.md
@@ -1,0 +1,9 @@
+---
+title: Generic constants node
+authors: ["@mbrea-c"]
+pull_requests: [141]
+---
+
+Having to add a custom constant node for each `DataValue` type is
+boilerplate-heavy and cumbersome. The `Constants` node lets you configure
+any number of constant values per node of any `DataValue` type.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Pin to old version due to https://github.com/rust-lang/rust-analyzer/issues/21715
 channel = "nightly"
-components = ["rustfmt", "rust-src"]
-profile = "minimal"
+components = ["rustfmt", "rust-src", "clippy"]
+profile = "default"


### PR DESCRIPTION
This PR adds a generic `Constants` node that lets you configure an arbitrary set of constants to output. The goal is that this will be able to replace type-specific constant nodes (so we can eventually deprecate `ConstF32`, `ConstBool`, etc).