### PR TITLE
chore: remove editproxy trait, replacing with custom node editors

### DIFF
--- a/crates/bevy_animation_graph_builtin_nodes/src/blend_space_node.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/blend_space_node.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_animation_graph_core::{
     animation_graph::TimeUpdate,
-    animation_node::{EditProxy, NodeLike, ReflectEditProxy, ReflectNodeLike},
+    animation_node::{NodeLike, ReflectNodeLike},
     context::{new_context::NodeContext, spec_context::SpecContext},
     edge_data::DataSpec,
     errors::GraphError,
@@ -34,7 +34,7 @@ pub struct PointElement {
 /// This node is useful, for example, to blend between directional movement and strafe animations
 /// in a shooter game.
 #[derive(Reflect, Clone, Debug, Default)]
-#[reflect(Default, NodeLike, EditProxy)]
+#[reflect(Default, NodeLike, Serialize, Deserialize)]
 #[type_path = "bevy_animation_graph::builtin_nodes"]
 pub struct BlendSpaceNode {
     pub mode: BlendMode,
@@ -223,31 +223,49 @@ impl NodeLike for BlendSpaceNode {
 }
 
 #[derive(Clone, Reflect, Serialize, Deserialize)]
-pub struct FlipLRProxy {
+pub struct BlendSpaceSerial {
     pub mode: BlendMode,
     pub sync_mode: BlendSyncMode,
     pub points: Vec<PointElement>,
 }
 
-impl EditProxy for BlendSpaceNode {
-    type Proxy = FlipLRProxy;
-
-    fn update_from_proxy(proxy: &Self::Proxy) -> Self {
+impl From<BlendSpaceSerial> for BlendSpaceNode {
+    fn from(value: BlendSpaceSerial) -> Self {
         Self {
-            mode: proxy.mode,
-            sync_mode: proxy.sync_mode.clone(),
-            points: proxy.points.clone(),
+            mode: value.mode,
+            sync_mode: value.sync_mode.clone(),
+            points: value.points.clone(),
             triangulation: Triangulation::from_points_delaunay(
-                proxy.points.clone().into_iter().map(|x| x.point).collect(),
+                value.points.clone().into_iter().map(|x| x.point).collect(),
             ),
         }
     }
+}
 
-    fn make_proxy(&self) -> Self::Proxy {
-        Self::Proxy {
-            mode: self.mode,
-            sync_mode: self.sync_mode.clone(),
-            points: self.points.clone(),
+impl From<BlendSpaceNode> for BlendSpaceSerial {
+    fn from(value: BlendSpaceNode) -> Self {
+        Self {
+            mode: value.mode,
+            sync_mode: value.sync_mode.clone(),
+            points: value.points.clone(),
         }
+    }
+}
+
+impl Serialize for BlendSpaceNode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        BlendSpaceSerial::from(self.clone()).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for BlendSpaceNode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(BlendSpaceSerial::deserialize(deserializer)?.into())
     }
 }

--- a/crates/bevy_animation_graph_builtin_nodes/src/flip_lr_node.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/flip_lr_node.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_animation_graph_core::{
-    animation_node::{EditProxy, NodeLike, ReflectNodeLike},
+    animation_node::{NodeLike, ReflectNodeLike},
     context::{new_context::NodeContext, spec_context::SpecContext},
     edge_data::DataSpec,
     errors::GraphError,
@@ -8,7 +8,7 @@ use bevy_animation_graph_core::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Reflect, Clone, Debug, Serialize, Deserialize)]
+#[derive(Reflect, Clone, Debug)]
 #[reflect(Default, NodeLike, Serialize, Deserialize)]
 #[type_path = "bevy_animation_graph::builtin_nodes"]
 pub struct FlipLRNode {
@@ -73,24 +73,46 @@ impl NodeLike for FlipLRNode {
     }
 }
 
-#[derive(Clone, Reflect)]
+#[derive(Clone, Reflect, Serialize, Deserialize)]
 pub struct FlipLRProxy {
     pub config: SymmetryConfigSerial,
 }
 
-impl EditProxy for FlipLRNode {
-    type Proxy = FlipLRProxy;
-
-    fn update_from_proxy(proxy: &Self::Proxy) -> Self {
-        Self {
-            // TODO: This will fail if the regex is incorrect, may cause some editor crashes
-            config: proxy.config.to_value().unwrap(),
+impl From<&FlipLRNode> for FlipLRProxy {
+    fn from(value: &FlipLRNode) -> Self {
+        FlipLRProxy {
+            config: SymmetryConfigSerial::from_value(&value.config),
         }
     }
+}
 
-    fn make_proxy(&self) -> Self::Proxy {
-        Self::Proxy {
-            config: SymmetryConfigSerial::from_value(&self.config),
-        }
+impl TryFrom<&FlipLRProxy> for FlipLRNode {
+    type Error = regex::Error;
+
+    fn try_from(value: &FlipLRProxy) -> std::result::Result<Self, Self::Error> {
+        Ok(Self {
+            config: value.config.to_value()?,
+        })
+    }
+}
+
+impl Serialize for FlipLRNode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        FlipLRProxy::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for FlipLRNode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let ser = FlipLRProxy::deserialize(deserializer)?;
+
+        Ok(Self::try_from(&ser)
+            .map_err(|_| serde::de::Error::custom("Failed to parse regular expression"))?)
     }
 }

--- a/crates/bevy_animation_graph_builtin_nodes/src/flip_lr_node.rs
+++ b/crates/bevy_animation_graph_builtin_nodes/src/flip_lr_node.rs
@@ -112,7 +112,7 @@ impl<'de> Deserialize<'de> for FlipLRNode {
     {
         let ser = FlipLRProxy::deserialize(deserializer)?;
 
-        Ok(Self::try_from(&ser)
-            .map_err(|_| serde::de::Error::custom("Failed to parse regular expression"))?)
+        Self::try_from(&ser)
+            .map_err(|_| serde::de::Error::custom("Failed to parse regular expression"))
     }
 }

--- a/crates/bevy_animation_graph_core/src/animation_node/mod.rs
+++ b/crates/bevy_animation_graph_core/src/animation_node/mod.rs
@@ -1,12 +1,12 @@
 pub mod dyn_node_like;
 pub mod serial;
 
-use std::{any::TypeId, fmt::Debug};
+use std::fmt::Debug;
 
 use bevy::{
     platform::collections::HashMap,
     prelude::{Deref, DerefMut},
-    reflect::{FromType, prelude::*},
+    reflect::prelude::*,
 };
 use uuid::Uuid;
 
@@ -61,51 +61,6 @@ impl Clone for Box<dyn NodeLike> {
     fn clone(&self) -> Self {
         self.clone_node_like()
     }
-}
-
-#[derive(Clone)]
-pub struct ReflectEditProxy {
-    pub proxy_type_id: TypeId,
-    pub from_proxy: fn(&dyn Reflect) -> Box<dyn NodeLike>,
-    pub to_proxy: fn(&dyn NodeLike) -> Box<dyn Reflect>,
-}
-
-impl<T> FromType<T> for ReflectEditProxy
-where
-    T: EditProxy + NodeLike,
-{
-    fn from_type() -> Self {
-        Self {
-            proxy_type_id: TypeId::of::<<T as EditProxy>::Proxy>(),
-            from_proxy: from_proxy::<T>,
-            to_proxy: to_proxy::<T>,
-        }
-    }
-}
-
-fn from_proxy<T: EditProxy + NodeLike>(proxy: &dyn Reflect) -> Box<dyn NodeLike> {
-    if proxy.type_id() == TypeId::of::<T::Proxy>() {
-        let proxy = proxy.downcast_ref::<T::Proxy>().unwrap();
-        Box::new(T::update_from_proxy(proxy))
-    } else {
-        panic!("Type mismatch")
-    }
-}
-
-fn to_proxy<T: EditProxy + NodeLike>(node: &dyn NodeLike) -> Box<dyn Reflect> {
-    if node.type_id() == TypeId::of::<T>() {
-        let node = node.as_any().downcast_ref::<T>().unwrap();
-        Box::new(T::make_proxy(node))
-    } else {
-        panic!("Type mismatch")
-    }
-}
-
-pub trait EditProxy {
-    type Proxy: Reflect + Clone;
-
-    fn update_from_proxy(proxy: &Self::Proxy) -> Self;
-    fn make_proxy(&self) -> Self::Proxy;
 }
 
 #[derive(Clone, Reflect, Debug, Default)]

--- a/crates/bevy_animation_graph_core/src/symmetry/serial.rs
+++ b/crates/bevy_animation_graph_core/src/symmetry/serial.rs
@@ -47,10 +47,10 @@ impl PatternMapperSerial {
     pub fn to_value(&self) -> Result<PatternMapper, regex::Error> {
         let regex = Regex::new(&format!(
             "({})({}|{})({})",
-            &self.pattern_before,
+            self.pattern_before,
             escape(&self.key_1),
             escape(&self.key_2),
-            &self.pattern_after,
+            self.pattern_after,
         ))?;
 
         Ok(PatternMapper {

--- a/crates/bevy_animation_graph_editor/src/ui/node_editors/flip_lr.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/node_editors/flip_lr.rs
@@ -1,0 +1,26 @@
+use bevy_animation_graph::builtin_nodes::flip_lr_node::{FlipLRNode, FlipLRProxy};
+
+use crate::ui::node_editors::{Editable, proxy_reflect_editor::ProxyReflectEditor};
+
+pub struct FlipLrNodeEditor;
+
+impl ProxyReflectEditor for FlipLrNodeEditor {
+    type Target = FlipLRNode;
+    type Proxy = FlipLRProxy;
+
+    fn value_to_proxy(&self, value: &Self::Target) -> Option<Self::Proxy> {
+        Some(value.into())
+    }
+
+    fn proxy_to_value(&self, proxy: &Self::Proxy) -> Option<Self::Target> {
+        proxy.try_into().ok()
+    }
+}
+
+impl Editable for FlipLRNode {
+    type Editor = FlipLrNodeEditor;
+
+    fn get_editor(&self) -> Self::Editor {
+        FlipLrNodeEditor
+    }
+}

--- a/crates/bevy_animation_graph_editor/src/ui/node_editors/mod.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/node_editors/mod.rs
@@ -3,8 +3,8 @@ use std::any::Any;
 use bevy::{app::App, ecs::world::World, reflect::FromType};
 use bevy_animation_graph::{
     builtin_nodes::{
-        blend_space_node::BlendSpaceNode, constants::Constants, global_input::GlobalInput,
-        ragdoll::const_ragdoll_config::ConstRagdollConfig,
+        blend_space_node::BlendSpaceNode, constants::Constants, flip_lr_node::FlipLRNode,
+        global_input::GlobalInput, ragdoll::const_ragdoll_config::ConstRagdollConfig,
     },
     core::animation_node::NodeLike,
 };
@@ -12,7 +12,9 @@ use bevy_animation_graph::{
 use crate::ui::node_editors::new_reflect_editor::NewReflectNodeEditor;
 
 pub mod blend_space;
+pub mod flip_lr;
 pub mod new_reflect_editor;
+pub mod proxy_reflect_editor;
 pub mod ragdoll_config;
 pub mod reflect_editor;
 
@@ -100,4 +102,5 @@ pub fn register_node_editables(app: &mut App) {
     app.register_type_data::<BlendSpaceNode, ReflectEditable>();
     app.register_type_data::<GlobalInput, ReflectEditable>();
     app.register_type_data::<Constants, ReflectEditable>();
+    app.register_type_data::<FlipLRNode, ReflectEditable>();
 }

--- a/crates/bevy_animation_graph_editor/src/ui/node_editors/proxy_reflect_editor.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/node_editors/proxy_reflect_editor.rs
@@ -1,0 +1,36 @@
+use bevy::{ecs::world::World, reflect::Reflect};
+
+use crate::ui::{node_editors::NodeEditor, reflect_lib::ReflectWidgetContext};
+
+pub trait ProxyReflectEditor: 'static {
+    type Target: 'static;
+    type Proxy: Reflect;
+
+    fn value_to_proxy(&self, value: &Self::Target) -> Option<Self::Proxy>;
+    fn proxy_to_value(&self, proxy: &Self::Proxy) -> Option<Self::Target>;
+}
+
+impl<T: ProxyReflectEditor> NodeEditor for T {
+    type Target = <T as ProxyReflectEditor>::Target;
+
+    fn show(
+        &self,
+        ui: &mut egui::Ui,
+        world: &mut World,
+        node: &mut Self::Target,
+    ) -> egui::Response {
+        let Some(mut proxy) = self.value_to_proxy(node) else {
+            return ui.allocate_rect(egui::Rect::ZERO, egui::Sense::empty());
+        };
+
+        let response = ReflectWidgetContext::scope(world, |ctx| ctx.draw(ui, &mut proxy));
+
+        if response.changed()
+            && let Some(value) = self.proxy_to_value(&proxy)
+        {
+            *node = value;
+        }
+
+        response
+    }
+}

--- a/crates/bevy_animation_graph_editor/src/ui/node_editors/reflect_editor.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/node_editors/reflect_editor.rs
@@ -1,5 +1,5 @@
 use bevy::ecs::world::World;
-use bevy_animation_graph::core::animation_node::{NodeLike, ReflectEditProxy};
+use bevy_animation_graph::core::animation_node::NodeLike;
 
 use crate::ui::{node_editors::DynNodeEditor, utils::using_inspector_env};
 
@@ -14,14 +14,8 @@ impl DynNodeEditor for ReflectNodeEditor {
         node: &mut dyn NodeLike,
     ) -> egui::Response {
         let mut response = ui.allocate_response(egui::Vec2::ZERO, egui::Sense::hover());
-        let type_id = node.as_any().type_id();
         let changed = using_inspector_env(world, |mut env| {
-            if let Some(edit_proxy) = env.type_registry.get_type_data::<ReflectEditProxy>(type_id) {
-                let mut proxy = (edit_proxy.to_proxy)(node);
-                env.ui_for_reflect_with_options(proxy.as_partial_reflect_mut(), ui, ui.id(), &())
-            } else {
-                env.ui_for_reflect(node.as_partial_reflect_mut(), ui)
-            }
+            env.ui_for_reflect(node.as_partial_reflect_mut(), ui)
         });
 
         if changed {

--- a/crates/bevy_animation_graph_editor/src/ui/reflect_lib/mod.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/reflect_lib/mod.rs
@@ -11,7 +11,10 @@ use bevy::{
     },
 };
 
-use crate::ui::{generic_widgets::picker::PickerWidget, reflect_lib::list_handler::handle_list};
+use crate::ui::{
+    generic_widgets::picker::PickerWidget, reflect_lib::list_handler::handle_list,
+    utils::maybe_response::MaybeResponse,
+};
 
 pub mod default_registry;
 pub mod list_handler;
@@ -82,8 +85,8 @@ impl<'a> ReflectWidgetContext<'a> {
             ));
         };
 
-        ui.scope(|ui| {
-            let mut response = ui.allocate_response(egui::Vec2::ZERO, egui::Sense::empty());
+        ui.vertical(|ui| {
+            let mut maybe_response = MaybeResponse::default();
             match type_info {
                 TypeInfo::Struct(struct_info) => {
                     let r_struct = value.reflect_mut().as_struct().unwrap();
@@ -97,8 +100,8 @@ impl<'a> ReflectWidgetContext<'a> {
                                 continue;
                             };
 
-                            response |= ui.label(format!("{}:", field_name));
-                            response |= self.draw(ui, field);
+                            maybe_response |= ui.label(format!("{}:", field_name));
+                            maybe_response |= self.draw(ui, field);
 
                             ui.end_row();
                         }
@@ -115,24 +118,24 @@ impl<'a> ReflectWidgetContext<'a> {
                             continue;
                         };
 
-                        response |= self.draw(ui, field);
+                        maybe_response |= self.draw(ui, field);
                     }
                 }
                 TypeInfo::Tuple(_tuple_info) => {
-                    response |= ui.label("Tuples not implemented yet");
+                    maybe_response |= ui.label("Tuples not implemented yet");
                 }
                 TypeInfo::List(list_info) => {
-                    response |= handle_list(self, ui, value, list_info);
-                    response |= ui.label("Lists not implemented yet");
+                    maybe_response |= handle_list(self, ui, value, list_info);
+                    maybe_response |= ui.label("Lists not implemented yet");
                 }
                 TypeInfo::Array(_array_info) => {
-                    response |= ui.label("Arrays not implemented yet");
+                    maybe_response |= ui.label("Arrays not implemented yet");
                 }
                 TypeInfo::Map(_map_info) => {
-                    response |= ui.label("Maps not implemented yet");
+                    maybe_response |= ui.label("Maps not implemented yet");
                 }
                 TypeInfo::Set(_set_info) => {
-                    response |= ui.label("Sets not implemented yet");
+                    maybe_response |= ui.label("Sets not implemented yet");
                 }
                 TypeInfo::Enum(enum_info) => {
                     let r_enum = value.reflect_mut().as_enum().unwrap();
@@ -158,18 +161,18 @@ impl<'a> ReflectWidgetContext<'a> {
                                     .inner;
 
                                 if variant_response.changed() {
-                                    response.mark_changed();
+                                    maybe_response.mark_changed();
                                 }
                             }
                         },
                     );
 
-                    response |= picker_response.response;
+                    maybe_response |= picker_response.response;
 
-                    if response.changed()
+                    if maybe_response.changed()
                         && let Some(default_value) = self.default_variant(current_value, enum_info)
                     {
-                        response.mark_changed();
+                        maybe_response.mark_changed();
                         r_enum.apply(&default_value);
                     }
 
@@ -187,8 +190,8 @@ impl<'a> ReflectWidgetContext<'a> {
                                         continue;
                                     };
 
-                                    response |= ui.label(format!("{}:", field_name));
-                                    response |= self.draw(ui, field);
+                                    maybe_response |= ui.label(format!("{}:", field_name));
+                                    maybe_response |= self.draw(ui, field);
 
                                     ui.end_row();
                                 }
@@ -204,17 +207,19 @@ impl<'a> ReflectWidgetContext<'a> {
                                     continue;
                                 };
 
-                                response |= self.draw(ui, field);
+                                maybe_response |= self.draw(ui, field);
                             }
                         }
                         VariantType::Unit => {}
                     }
                 }
                 TypeInfo::Opaque(_opaque_info) => {
-                    response |= ui.label("Opaque not implemented yet");
+                    maybe_response |= ui.label("Opaque not implemented yet");
                 }
             }
-            response
+            maybe_response
+                .0
+                .unwrap_or_else(|| ui.allocate_rect(egui::Rect::ZERO, egui::Sense::empty()))
         })
         .inner
     }

--- a/crates/bevy_animation_graph_editor/src/ui/utils/maybe_response.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/utils/maybe_response.rs
@@ -1,0 +1,26 @@
+use std::ops::BitOrAssign;
+
+#[derive(Default)]
+pub struct MaybeResponse(pub Option<egui::Response>);
+
+impl MaybeResponse {
+    pub fn changed(&self) -> bool {
+        self.0.as_ref().is_some_and(|inner| inner.changed())
+    }
+
+    pub fn mark_changed(&mut self) {
+        if let Some(inner) = &mut self.0 {
+            inner.mark_changed();
+        }
+    }
+}
+
+impl BitOrAssign<egui::Response> for MaybeResponse {
+    fn bitor_assign(&mut self, rhs: egui::Response) {
+        if let Some(inner) = &mut self.0 {
+            *inner |= rhs;
+        } else {
+            self.0 = Some(rhs);
+        }
+    }
+}

--- a/crates/bevy_animation_graph_editor/src/ui/utils/mod.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/utils/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 pub mod collapsing;
+pub mod maybe_response;
 pub mod popup;
 pub mod ui_buffer;
 

--- a/crates/bevy_animation_graph_editor/src/ui/utils/ui_buffer.rs
+++ b/crates/bevy_animation_graph_editor/src/ui/utils/ui_buffer.rs
@@ -19,7 +19,6 @@ where
         {
             buffer
         } else {
-            println!("Buffer invalidated");
             Self::new(ui, meta, value)
         }
     }


### PR DESCRIPTION
The edit proxy trait is currently broken. It's also not the right solution to the problem of nodes needing custom editor-friendly representation, unnecessarily coupling editor logic with the core library.

Instead we should have two solutions:
* Custom `Serialize` / `Deserialize` implementations for cases where node need non-serializable data (e.g. the triangulation in blend spaces, regex objects in symmetry nodes).
* Custom node editor implementations for optionally drawing custom editor UI for any node. I've added a `ProxyReflectEditor` helper for the case that `EditProxy` was trying to solve for originally, but the custom editor solution is much more flexible (e.g. we can have custom drawing for the triangulation in blend space nodes eventually).